### PR TITLE
docs: refresh release docs for 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ clutch/
 | [`AGENTS.md`](./AGENTS.md) | 多 AI 工具入口索引 |
 | [`CONTRIBUTING.md`](./CONTRIBUTING.md) | 如何贡献、Phase 1 PR 政策 |
 | [`SECURITY.md`](./SECURITY.md) · [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md) | 漏洞报告 · 社区准则 |
-| [`CHANGELOG.md`](./CHANGELOG.md) | 版本变更（当前 **1.0.0**） |
+| [`CHANGELOG.md`](./CHANGELOG.md) | 版本变更（当前 **1.0.1**） |
 
 ### 产品与架构（`docs/`）
 
@@ -90,7 +90,7 @@ clutch/
 
 ## 兼容性
 
-> 详细稳定性见 [`docs/STABILITY.md`](./docs/STABILITY.md)。**0.x 版本可能随时 breaking change。**
+> 详细稳定性见 [`docs/STABILITY.md`](./docs/STABILITY.md)。当前 `1.0.x` 遵循语义化版本；历史 pre-1.0 版本可能包含 breaking change。
 
 ### 平台
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@
 | 1.0.x   | Yes       |
 | < 1.0   | No        |
 
-While Clutch is `0.x`, security fixes land on `main` and ship with the next semver tag. See [`docs/STABILITY.md`](docs/STABILITY.md).
+Security fixes for supported `1.0.x` releases land on `main` and ship with the next semver tag. See [`docs/STABILITY.md`](docs/STABILITY.md).
 
 ## Reporting a vulnerability
 
@@ -62,7 +62,7 @@ We coordinate public disclosure after a fix is available or an agreed embargo en
 
 ## Known limitations (current release)
 
-Summary only — details in [`docs/OPEN_SOURCE_RELEASE.md`](docs/OPEN_SOURCE_RELEASE.md) §5:
+Summary only — roadmap context in [`docs/OPEN_SOURCE_RELEASE.md`](docs/OPEN_SOURCE_RELEASE.md) §7.2:
 
 | Topic | Current behavior | Planned |
 |-------|------------------|---------|

--- a/docs/PRODUCT_INTRO.md
+++ b/docs/PRODUCT_INTRO.md
@@ -203,4 +203,4 @@ pnpm tauri build
 
 ---
 
-*本文档基于最新的前后端实现编写。关联架构设计详述见 [系统架构文档](file:///Users/fancy/clutch/docs/ARCHITECTURE.md)；文件定位见 [FILEMAP.md](file:///Users/fancy/clutch/memory/FILEMAP.md)。*
+*本文档基于最新的前后端实现编写。关联架构设计详述见 [系统架构文档](./ARCHITECTURE.md)；文件定位见 [FILEMAP.md](../memory/FILEMAP.md)。*

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -19,9 +19,9 @@
 
 | 模块 / 接口 | 稳定性 | 说明 |
 |-------------|--------|------|
-| **Workflow JSON Schema** (`workflows/workflow.schema.json`) | **Stable**（1.0 前为 Beta） | 用户工作流与模板；Compiler 输入契约 |
+| **Workflow JSON Schema** (`workflows/workflow.schema.json`) | **Stable**（pre-1.0 为 Beta） | 用户工作流与模板；Compiler 输入契约 |
 | **WebSocket 信封** (`event` + `data`，如 `state_patch`) | **Beta** | 事件名稳定倾向高；`data.patch` 字段随 `ClutchState` 演进 |
-| **HTTP REST `/api/*`** | **Experimental** | 路由与 payload 随功能迭代；**1.0 前不保证兼容** |
+| **HTTP REST `/api/*`** | **Experimental** | 路由与 payload 仍随功能迭代；正式稳定前不保证兼容 |
 | **`ClutchState` 字段** | **Experimental** | 前端仅投影 WS；字段可增删 |
 | **LangGraph 内部图 / Compiler 实现** | **Internal** | `services/orchestrator/src/compiler/`、`workflow_runtime.py` |
 | **Engine Router / Hybrid 运行时** | **Internal** | `engine_router.py`、`shell_exec_runtime.py` |
@@ -51,7 +51,7 @@ memory/                                    # 维护者运行态，非 API
 
 ## 3. 版本与 Release 生命周期
 
-当前版本：**1.0.0**（首个公开发布；各模块稳定性见 §2）。
+当前版本：**1.0.1**（各模块稳定性见 §2）。
 
 | 阶段 | 版本号 | 含义 |
 |------|--------|------|
@@ -61,10 +61,10 @@ memory/                                    # 维护者运行态，非 API
 | **LTS** | `1.x` 长期分支（未来） | 仅安全修复；**尚未承诺** |
 | **Deprecated** | 文档标注 + 至少一 minor 过渡期 | 移除前在 `CHANGELOG.md` 说明 |
 
-### 0.x 政策（重要）
+### Pre-1.0 政策（历史说明）
 
-> **Until 1.0, breaking changes are expected.**  
-> 升级 minor（如 `0.2` → `0.3`）后若 Workflow 无法加载或 API 报错，请先查 `CHANGELOG.md`，而非假定兼容。
+> **Before 1.0, breaking changes were expected.**
+> 如果仍在使用历史 `0.x` 版本，升级 minor（如 `0.2` → `0.3`）后若 Workflow 无法加载或 API 报错，请先查 `CHANGELOG.md`，而非假定兼容。
 
 | 变更类型 | 0.x 处理方式 |
 |----------|----------------|


### PR DESCRIPTION
## Summary

同步几处当前文档里的 1.0.1 版本口径：修正 README / SECURITY / STABILITY 中仍停留在 1.0.0 或 0.x 的描述，修正 SECURITY 里指向不存在章节的引用，并把 PRODUCT_INTRO 末尾的本机 file:///Users/... 链接改成仓库相对链接。

## Type

- [ ] Bug fix
- [ ] Feature (in [PROJECT_SCOPE](docs/PROJECT_SCOPE.md))
- [x] Docs only
- [ ] Refactor (no behavior change)

## Extension / stability

- [ ] I read [EXTENSIBILITY.md](docs/EXTENSIBILITY.md) — this touches an **official extension point** only
- [ ] This changes **Experimental** or **Internal** APIs (noted in PR)
- [ ] Breaking change (0.x: documented in PR; post-1.0: needs CHANGELOG Breaking section)

## Testing

- `git diff --check main...HEAD`：passed
- targeted Markdown link check for touched docs：`TOTAL_MISSING=0`

- [x] Ran locally（仅文档检查；本 PR 为 docs-only，未运行完整 `./scripts/verify.sh`）
- [ ] Added/updated tests if behavior changed

## Screenshots / logs

N/A，纯文档改动。

## Related

N/A