### PR TITLE
docs(agents): add Cursor Cloud environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,17 @@
 **For GitHub Copilot users:** see [`.github/copilot-instructions.md`](./.github/copilot-instructions.md).
 
 **For frontend UI work:** see [`docs/UI_UX_GUIDELINES.md`](./docs/UI_UX_GUIDELINES.md).
+
+---
+
+## Cursor Cloud specific instructions
+
+Durable notes for cloud agents (the startup update script already runs `pnpm install` + `uv sync --extra dev` for the orchestrator). Standard commands live in [`CLAUDE.md`](./CLAUDE.md) §核心命令 and [`docs/BUILD_FROM_SOURCE.md`](./docs/BUILD_FROM_SOURCE.md); this section only captures non-obvious cloud gotchas.
+
+- **`uv` is not in the base image.** It is installed to `~/.local/bin` (added to `~/.bashrc`). If `uv` is missing from `PATH`, invoke it as `~/.local/bin/uv`.
+- **Run in web dev mode, not Tauri, on the Linux cloud VM.** `pnpm tauri:dev` targets macOS/Windows and needs the Rust WebKitGTK desktop toolchain, so it is not runnable headless here. Instead run the two services separately:
+  - Sidecar: `cd services/orchestrator && ~/.local/bin/uv run uvicorn src.main:app --reload --host 127.0.0.1 --port 8124`
+  - Frontend: `pnpm dev` (Vite on `:3000`, proxies `/api`, `/ws`, `/health` → `8124`). Health check: `curl -s http://127.0.0.1:8124/health` → `{"status":"ok",...}`.
+- **Web mode has no folder picker.** Workspace/folder selection needs Tauri desktop APIs, so onboarding blocks core features (chat, workflows). To unblock in the browser, authorize a workspace directly against the sidecar: `curl -X POST http://127.0.0.1:8124/api/workspaces -H 'Content-Type: application/json' -d '{"path":"/abs/path"}'` (auto-activates). Mark onboarding done via `curl -X POST http://127.0.0.1:8124/api/preferences/onboarding-complete`, then reload the page.
+- **Agent/chat runs need credentials.** Without a connected CLI or a cloud LLM API key (Settings → Models), sending a chat returns a clear "No API key configured for provider …" error — this is expected, not a bug. Workflow (SOP) editing on the canvas works without any keys.
+- **`pnpm lint` (`tsc --noEmit`) is not part of the CI gate** and currently has pre-existing type errors in some `*.test.ts` files. The authoritative verification is `./scripts/verify.sh` (build + vitest + pytest + doc-drift); `vitest` transpiles via esbuild so tests pass regardless.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for Clutch and records durable, non-obvious startup guidance for future cloud agents. The only code change is documentation: a new `## Cursor Cloud specific instructions` section in `AGENTS.md`.

Environment work performed (no code changes required — repo was already working):
- Installed `uv` (not in base image) → `~/.local/bin`; `pnpm install` + `uv sync --extra dev` for the orchestrator.
- Verified the full gate `./scripts/verify.sh` equivalent: `pnpm build`, `pnpm test` (125 passed), orchestrator `uv run pytest` (636 passed, 7 skipped), `check-doc-drift.sh` (0 errors).
- Ran the app in web dev mode (Linux VM can't run the macOS/Windows Tauri shell): sidecar on `:8124` + Vite on `:3000` with working proxy.

## Hello-world (core functionality)

Authorized a workspace via the sidecar API (web mode has no Tauri folder picker), then created a **"Hello World SOP"** workflow and placed a **Clutch Agent** node on the React Flow canvas — the flagship zero-code SOP editing flow. Also started a chat session (returns the expected "no API key configured" notice since no LLM key is set).

[clutch_workflow_hello_world_demo.mp4](https://cursor.com/agents/bc-8a1d2800-40c8-4f1e-918f-caf31727dc67/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclutch_workflow_hello_world_demo.mp4)

[Clutch Agent node placed on workflow canvas](https://cursor.com/agents/bc-8a1d2800-40c8-4f1e-918f-caf31727dc67/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclutch_workflow_node_placed.webp)

## Notes captured in AGENTS.md
- `uv` lives at `~/.local/bin`.
- Use web dev mode (sidecar + `pnpm dev`) on the cloud VM, not `pnpm tauri:dev`.
- Unblock onboarding in web mode by authorizing a workspace via `POST /api/workspaces`.
- Chat/agent runs need a CLI or LLM API key; workflow editing does not.
- `pnpm lint` is not in the CI gate and has pre-existing tsc errors; `./scripts/verify.sh` is authoritative.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a1d2800-40c8-4f1e-918f-caf31727dc67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a1d2800-40c8-4f1e-918f-caf31727dc67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

