### PR TITLE
chore(scripts): fall back to bare `pnpm` when corepack is unavailable

### DIFF
--- a/scripts/tauri-dev.py
+++ b/scripts/tauri-dev.py
@@ -52,6 +52,18 @@ def command(name: str) -> str:
     return name
 
 
+def pnpm_launcher() -> list[str]:
+    """Prefer corepack-shimmed pnpm; fall back to bare pnpm.
+
+    Corepack ensures the packageManager pin in package.json is honored, but it
+    is not present on installs that use Homebrew/npm-globally-installed pnpm.
+    In those cases fall back to whatever `pnpm` resolves on PATH.
+    """
+    if shutil.which("corepack"):
+        return [command("corepack"), "pnpm"]
+    return [command("pnpm")]
+
+
 def resolve_uv() -> str:
     found = command("uv")
     if found != "uv":
@@ -95,7 +107,7 @@ def start_vite() -> subprocess.Popen[bytes]:
         creationflags = subprocess.CREATE_NEW_PROCESS_GROUP
         start_new_session = False
     proc = subprocess.Popen(
-        [command("corepack"), "pnpm", "--filter", "@clutch/desktop", "dev"],
+        [*pnpm_launcher(), "--filter", "@clutch/desktop", "dev"],
         cwd=REPO_ROOT,
         stdout=log,
         stderr=subprocess.STDOUT,
@@ -141,7 +153,7 @@ def main() -> int:
     env.setdefault("CLUTCH_RUNTIME_MODE", "hybrid")
     env["CLUTCH_UV_BIN"] = resolve_uv()
     return subprocess.call(
-        [command("corepack"), "pnpm", "tauri", "dev", "--no-dev-server-wait"],
+        [*pnpm_launcher(), "tauri", "dev", "--no-dev-server-wait"],
         cwd=DESKTOP,
         env=env,
     )


### PR DESCRIPTION
## Summary

Drive-by fix: `pnpm tauri:dev` fails on machines where `pnpm` was installed via Homebrew or a global npm, because the launcher script hard-codes `corepack pnpm ...` and corepack was never enabled.

## Repro

Fresh macOS with `brew install pnpm`:

```bash
cd apps/desktop
pnpm tauri:dev
# → FileNotFoundError: [Errno 2] No such file or directory: 'corepack'
#   ELIFECYCLE  Command failed with exit code 1.
```

## Fix

Add a small `pnpm_launcher()` helper: prefer corepack when it's on PATH (preserves the `packageManager` pin in `package.json`), otherwise fall back to whatever `pnpm` resolves on PATH.

Both invocation sites (`start_vite` for Vite, and the final `tauri dev` call) use the same helper, so behavior stays consistent.

```diff
+def pnpm_launcher() -> list[str]:
+    if shutil.which("corepack"):
+        return [command("corepack"), "pnpm"]
+    return [command("pnpm")]
```

## Impact

- **corepack-enabled setups** (previously working): no change — helper still resolves to `corepack pnpm ...`.
- **Homebrew / npm-global pnpm** (previously broken): now works out of the box.
- No `package.json` / `packageManager` semantics changed; corepack still gets priority when present.
