### PR TITLE
chore(scripts): auto-detect orchestrator venv python in build-sidecar.py

### DIFF
--- a/scripts/build-sidecar.py
+++ b/scripts/build-sidecar.py
@@ -10,6 +10,22 @@ import sys
 from pathlib import Path
 
 
+def resolve_pyinstaller_python(orchestrator: Path) -> str:
+    """Prefer the orchestrator uv-managed venv (where PyInstaller lives).
+
+    Falls back to `sys.executable`, but that only works if the caller already
+    activated the orchestrator venv or installed PyInstaller globally — which
+    is not how the project is set up (see services/orchestrator/pyproject.toml).
+    """
+    if os.name == "nt":
+        candidate = orchestrator / ".venv" / "Scripts" / "python.exe"
+    else:
+        candidate = orchestrator / ".venv" / "bin" / "python"
+    if candidate.is_file():
+        return str(candidate)
+    return sys.executable
+
+
 def main() -> int:
     root = Path(__file__).resolve().parents[1]
     orchestrator = root / "services" / "orchestrator"
@@ -24,8 +40,9 @@ def main() -> int:
     triple = subprocess.check_output(
         ["rustc", "--print", "host-tuple"], text=True
     ).strip()
+    python = resolve_pyinstaller_python(orchestrator)
     subprocess.run(
-        [sys.executable, "-m", "PyInstaller", "clutch.spec", "--noconfirm", "--clean"],
+        [python, "-m", "PyInstaller", "clutch.spec", "--noconfirm", "--clean"],
         cwd=orchestrator,
         check=True,
     )


### PR DESCRIPTION
## Summary

Drive-by fix: `python3 scripts/build-sidecar.py` fails out-of-the-box because it invokes `sys.executable`, which points at the caller's system interpreter — where PyInstaller is not installed.

PyInstaller is pinned as a dev dependency of `services/orchestrator` (`pyproject.toml`), i.e. it lives inside the orchestrator's uv-managed venv. Currently the docs/tooling expect users to `source .venv/bin/activate` first — undocumented and easy to miss.

## Repro

Fresh clone, follow the README build-from-source flow:

```bash
cd services/orchestrator && uv sync --extra dev && cd ../..
python3 scripts/build-sidecar.py

# → /Library/.../python3.9: No module named PyInstaller
#   subprocess.CalledProcessError: ... 'clutch.spec' ... exit status 1
```

This bites `pnpm tauri:dev` too, since the Tauri build script fails without the sidecar binary at `apps/desktop/src-tauri/binaries/orchestrator-<triple>`.

## Fix

Add a small helper that prefers the orchestrator's venv Python if present, and keeps `sys.executable` as a fallback:

```python
def resolve_pyinstaller_python(orchestrator: Path) -> str:
    if os.name == "nt":
        candidate = orchestrator / ".venv" / "Scripts" / "python.exe"
    else:
        candidate = orchestrator / ".venv" / "bin" / "python"
    if candidate.is_file():
        return str(candidate)
    return sys.executable
```

Both invocation styles now Just Work:

- **Fresh contributor** who ran `uv sync --extra dev`: script auto-picks `.venv/bin/python`. ✅
- **Contributor who activated the venv first** or installed PyInstaller globally: `sys.executable` fallback stays valid. ✅

Windows path handled (`Scripts/python.exe`).

## Impact

- No functional change for existing setups.
- Removes an undocumented setup step for new contributors trying `pnpm tauri:dev`.
