### PR TITLE
fix(zcode-cli): drop --session-id / --append-system-prompt (unsupported by zcode)

### DIFF
--- a/services/orchestrator/src/adapters/zcode_cli_adapter.py
+++ b/services/orchestrator/src/adapters/zcode_cli_adapter.py
@@ -15,6 +15,19 @@ Notes vs Codex CLI (a superficially similar engine):
   `--dangerously-skip-permissions` on other CLIs.
 - Session resumption uses `--resume <sessionId>` with `sess_...`-prefixed ids.
 - `--json` emits a machine-readable envelope Clutch can parse.
+
+Flag compatibility (v0.15.x):
+- ZCode does NOT recognize `--session-id <uuid>`. Attempts to pass one exit
+  with `Unknown option '--session-id'`. Session resumption is via `--resume
+  <sess_...>` only, and expects a ZCode-issued sessionId (different id-space
+  from Clutch's `session_id`), so we default to `history_only` mode here.
+  When we later want persistence, we should extract the `sessionId` from
+  zcode's `--json` response and pass it as `resume_session_id` for the next
+  turn (with a `sess_` prefix already present); this is future work.
+- ZCode does NOT recognize `--append-system-prompt <text>`; there is no
+  direct equivalent flag. We prepend the system prompt into the user prompt
+  body instead (`supports_append_system_prompt=False`), matching the pattern
+  used by other adapters that can't append.
 """
 
 from __future__ import annotations
@@ -60,9 +73,18 @@ def chat_zcode_cli(
     return chat_generic_cli(
         prompt,
         binary=binary or "zcode",
-        conversation_mode="separate",
+        # ZCode does not accept `--session-id <uuid>`; Clutch's session_id
+        # lives in a different id-space than ZCode's sess_... anyway. Use
+        # `history_only` so compose_cli_argv() emits neither `--session-id`
+        # nor `--resume`. Future: parse zcode --json response for its
+        # `sessionId` and pass as `resume_session_id` on the next turn.
+        conversation_mode="history_only",
         extra_args=extra_args,
         prepend_system_prompt=False,
+        # ZCode has no `--append-system-prompt` equivalent. Setting this to
+        # False makes chat_generic_cli() prepend the system prompt into the
+        # user prompt body instead.
+        supports_append_system_prompt=False,
         cwd=cwd,
         system_prompt=system_prompt,
         session_id=session_id,

--- a/services/orchestrator/tests/test_cli_adapter.py
+++ b/services/orchestrator/tests/test_cli_adapter.py
@@ -275,3 +275,73 @@ def test_compose_cli_argv_opencode_run_auto() -> None:
         extra_args=["run", "--auto"],
     )
     assert cmd == ["opencode", "run", "--auto", "nihao"]
+
+
+def test_compose_cli_argv_zcode_omits_session_id_and_append_system_prompt() -> None:
+    """ZCode CLI (v0.15.x) does not accept `--session-id` or `--append-system-prompt`.
+
+    Guards against regression of the flag-passing bug reported in issue #50:
+    zcode-cli adapter must (a) not emit `--session-id <uuid>` and (b) not emit
+    `--append-system-prompt <text>`, even when the orchestrator passes both a
+    Clutch session_id and a system_prompt.
+    """
+    cmd = compose_cli_argv(
+        binary="zcode",
+        effective_prompt="ping",
+        prompt_flag="-p",
+        conversation_mode="history_only",
+        session_id="cbea05c8-920c-403e-841f-ac322b27d9d7",
+        extra_args=["--json", "--mode", "yolo"],
+        prepend_system_prompt=False,
+        system_prompt="You are ZCode CLI.",
+        supports_append_system_prompt=False,
+    )
+    # Session-related flags must be absent (id-space mismatch with zcode's sess_...).
+    assert "--session-id" not in cmd
+    assert "--resume" not in cmd
+    # No --append-system-prompt: zcode has no equivalent flag.
+    assert "--append-system-prompt" not in cmd
+    # Expected argv shape.
+    assert cmd == ["zcode", "--json", "--mode", "yolo", "-p", "ping"]
+
+
+def test_chat_generic_cli_zcode_prepends_system_prompt_when_append_unsupported() -> None:
+    """When `supports_append_system_prompt=False`, chat_generic_cli() must
+    prepend the system prompt into the user prompt body instead of emitting
+    `--append-system-prompt`. This preserves identity/behavioral context for
+    CLIs like ZCode that have no append flag."""
+    captured: dict[str, list[str]] = {}
+
+    def fake_run_cli(cmd, **kwargs):  # noqa: ANN001
+        captured["cmd"] = cmd
+        class _Result:
+            ok = True
+            stdout = "hi"
+            stderr = ""
+            exit_code = 0
+        return _Result()
+
+    out = chat_generic_cli(
+        "list the files",
+        binary="zcode",
+        conversation_mode="history_only",
+        extra_args=["--json", "--mode", "yolo"],
+        prepend_system_prompt=False,
+        supports_append_system_prompt=False,
+        system_prompt="You are ZCode CLI.",
+        session_id="cbea05c8-920c-403e-841f-ac322b27d9d7",
+        run_cli_fn=fake_run_cli,
+        prompt_flag="-p",
+    )
+    assert out == "hi"
+    cmd = captured["cmd"]
+    # No append flag emitted.
+    assert "--append-system-prompt" not in cmd
+    # No session-id flag emitted (history_only mode).
+    assert "--session-id" not in cmd
+    # System prompt got prepended into the -p prompt body.
+    idx = cmd.index("-p")
+    body = cmd[idx + 1]
+    assert body.startswith("You are ZCode CLI.")
+    assert "list the files" in body
+


### PR DESCRIPTION
## Summary

Fixes flag-passing bugs introduced in #43 (v1.2.0): the ZCode CLI adapter emits two flags that `zcode` (v0.15.x) does not recognize, causing every workflow step routed to a `zcode-cli` agent to exit 1 before doing any work.

**Fixes #50 · Fixes #51**

## Root cause

`services/orchestrator/src/adapters/zcode_cli_adapter.py` calls `chat_generic_cli()` with `conversation_mode="separate"` and default `supports_append_system_prompt=True`. Combined with the shared `compose_cli_argv()` in `cli_adapter.py`, this produces argv like:

```
zcode --json --mode yolo --session-id <uuid> -p "<prompt>" --append-system-prompt "<identity>"
```

But ZCode CLI does not accept:

1. **`--session-id <uuid>`** — zcode uses `--resume <sess_...>` only, and expects a zcode-issued sessionId (different id-space from Clutch's `session_id`). Passing `--session-id` exits with `Unknown option '--session-id'`.
2. **`--append-system-prompt <text>`** — zcode has no equivalent flag.

Downstream: zcode exits 1, prints usage-help to stderr; the usage-help mentions `login`; the orchestrator's failure classifier keyword-matches that and surfaces `zcode 需要登录` (see #51).

## Fix

Two small, well-motivated changes to `zcode_cli_adapter.py`, matching the pattern already established for Codex CLI (which also cannot append):

- **`conversation_mode="history_only"`** — `compose_cli_argv()` emits neither `--session-id` nor `--resume`. Future work: parse zcode's `--json` response for its `sessionId` and pass as `resume_session_id` on the next turn to support multi-turn persistence. Noted in the adapter docstring.
- **`supports_append_system_prompt=False`** — `chat_generic_cli()` prepends the system prompt into the user prompt body instead of emitting an unsupported flag. Preserves identity-injection behavior parity with other CLIs (this is important — see identity-injection comment I left on #50).

Also extends the module docstring with a "Flag compatibility (v0.15.x)" section documenting the id-space mismatch and the append-flag absence, so future contributors don't re-introduce the same bug.

## Tests

Two regression tests added in `tests/test_cli_adapter.py`:

- **`test_compose_cli_argv_zcode_omits_session_id_and_append_system_prompt`** — asserts the assembled argv contains neither `--session-id` nor `--resume` nor `--append-system-prompt`, even when the orchestrator passes both a `session_id` and a `system_prompt`.
- **`test_chat_generic_cli_zcode_prepends_system_prompt_when_append_unsupported`** — asserts the `system_prompt` gets prepended into the `-p` prompt body (via a mocked `run_cli_fn`).

```
uv run pytest tests/test_cli_adapter.py tests/test_tools_status.py
============================== 46 passed in 3.11s ==============================
```

44 existing + 2 new. No regressions.

## Local end-to-end verification (with a translation shim)

Before writing this PR, I ran the same fix locally as a shell shim intercepting the two flags before exec'ing the real `zcode.cjs`. With the shim in place, three workflows completed cleanly on Clutch v1.2.0:

| Workflow | Nodes | Result |
|---|---|---|
| `canvas-smoke-test` | 2 (agent_task/zcode-cli → end) | ✅ passed |
| `textbook-pipeline-linear` | 3 (agent_task/zcode-cli → agent_task/claude-cli → end) | ✅ passed |
| `textbook-pipeline-beta` | 5 (with human_gate/check) | Node 1 (zcode) delivered clean 32-chapter JSON; Node 3 (claude) delivered kp.json; blocked at Evaluator gate, but that's a separate issue (#52) |

Sample zcode `--json` envelope returned to the orchestrator in the passing runs:

```json
{
  "sessionId": "sess_ac56c070-83a4-4f25-9fe9-7e3f11fddab1",
  "response": "Hello from Clutch v1.2.0 canvas test.",
  "usage": {"source": "provider", "inputTokens": 21087, "outputTokens": 24, "totalTokens": 21111}
}
```

This PR replaces the shim by fixing the adapter at the source. After this lands, users of the ZCode CLI integration no longer need a shim.

## Related

- Introduced by #43
- Depends-on / superset of the fix requested in #50
- Also resolves #51 as a side-effect (no more zcode exit-1 → no more mistaken "sign-in required")
- **Does NOT resolve** #52 (Evaluator gate stall) or #53 (file_exists check) or #54 (agentType validation) or #55 (canvas downgrade banner) — those are separate concerns and remain open

## Compatibility

- No breaking changes for other CLI adapters (Claude, Codex, OpenCode, CodeBuddy, Cursor, MiMo, Agy).
- No changes to `cli_adapter.py`'s public interface — this PR only changes how `zcode_cli_adapter.py` calls `chat_generic_cli()`.
- Compatible with the D37 sidecar-hotpatch mechanism landed in v1.2.1: this fix is orchestrator-only and can be shipped as a hotpatch without a new DMG.
