### PR TITLE
feat(agents): stricter agent-config validation to catch silent mis-routing

### DIFF
--- a/services/orchestrator/src/agent_executor.py
+++ b/services/orchestrator/src/agent_executor.py
@@ -169,6 +169,30 @@ def execute_agent_task(
     result_message: dict[str, Any] | None = None
     task_failed = False
 
+    # Guard against a class of silent mis-routing observed in the wild (#54):
+    # the workflow node declares `tool: 'zcode-cli'` but the referenced agent's
+    # `agentType` is `'claude-cli'` (e.g. because it was copied from a template
+    # without updating the field). The router will dispatch by agentType, so
+    # execution silently goes to the wrong CLI while log lines still say
+    # `[<agent.name>]`. Surface the mismatch loudly so users can catch typos
+    # early. We deliberately do not refuse execution — some setups may want
+    # this deliberately (e.g. testing a workflow with a substitute engine).
+    if agent_dict and tool and tool not in {"", "llm"}:
+        from src.agent_type import agent_type_from_record, normalize_agent_type
+
+        agent_type = agent_type_from_record(agent_dict)
+        node_type = normalize_agent_type(tool)
+        if node_type != agent_type and node_type != "clutch":
+            warning = (
+                f"[ROUTER] warning: workflow node tool={tool!r} does not match "
+                f"agent.agentType={agent_type!r} (agent id={agent_dict.get('id')!r}, "
+                f"name={agent_dict.get('name')!r}). Routing will follow agentType "
+                f"({agent_type!r}); if this is a typo, edit the agent to match."
+            )
+            logs.append(warning)
+            if run_id:
+                stream_log(warning)
+
     if tool in {"claude-cli", "agy-cli", "agy", "antigravity-cli", "codex-cli", "codex", "aider-cli", "opencode-cli", "opencode", "mimo-cli", "mimo", "codebuddy-cli", "codebuddy", "cbc", "llm", "ollama", "ollama-cli", "zcode-cli", "zcode", ""}:
         from src.agent_type import resolve_model_for_agent
         from src.engine_router import route_engine

--- a/services/orchestrator/src/agent_storage.py
+++ b/services/orchestrator/src/agent_storage.py
@@ -7,10 +7,19 @@ import os
 from pathlib import Path
 from typing import Any
 
-from src.agent_type import migrate_agent_record
+from src.agent_type import migrate_agent_record, normalize_agent_type_strict
 
 AGENTS_ENV = "CLUTCH_AGENTS_DIR"
 BUILTIN_AGENT_ID = "clutch-agent"
+
+
+class AgentValidationError(ValueError):
+    """Raised when a user-submitted agent record fails validation.
+
+    Kept separate from generic ValueError so callers (e.g. the FastAPI layer)
+    can format a targeted 400 response instead of a 500.
+    """
+
 
 
 def get_builtin_agent() -> dict[str, Any]:
@@ -94,17 +103,40 @@ def list_agents() -> list[dict[str, Any]]:
     return [_effective_builtin(builtin_override), *user_agents]
 
 
+def _validate_user_agent(agent: dict[str, Any]) -> None:
+    """Reject user-submitted agent records with an unrecognized `agentType`.
+
+    Prior behavior: `migrate_agent_record` → `normalize_agent_type` silently
+    fell back to 'clutch' on typos (e.g. 'zcode' missing the '-cli' suffix),
+    which then caused the persisted agent to route to the built-in Clutch
+    engine instead of the CLI the user intended. See #54.
+    """
+    raw = str(agent.get("agentType", "")).strip()
+    if not raw:
+        return  # No agentType → defaults to 'clutch', that's fine.
+    try:
+        normalize_agent_type_strict(raw)
+    except ValueError as exc:
+        agent_id = agent.get("id") or "<no-id>"
+        raise AgentValidationError(
+            f"Agent {agent_id!r} has invalid agentType {raw!r}: {exc}"
+        ) from exc
+
+
 def save_agents(agents: list[dict[str, Any]]) -> list[dict[str, Any]]:
     path = _agents_file()
     builtin_override = next(
         (agent for agent in agents if agent.get("id") == BUILTIN_AGENT_ID),
         None,
     )
-    user_agents = [
-        migrate_agent_record(agent)
+    user_agent_inputs = [
+        agent
         for agent in agents
         if agent.get("id") != BUILTIN_AGENT_ID and not agent.get("builtin")
     ]
+    for agent in user_agent_inputs:
+        _validate_user_agent(agent)
+    user_agents = [migrate_agent_record(agent) for agent in user_agent_inputs]
     stored: list[dict[str, Any]] = []
     if builtin_override:
         stored.append(_effective_builtin(builtin_override))

--- a/services/orchestrator/src/agent_type.py
+++ b/services/orchestrator/src/agent_type.py
@@ -79,6 +79,33 @@ def normalize_agent_type(raw: str) -> str:
     return "clutch"
 
 
+def normalize_agent_type_strict(raw: str) -> str:
+    """Same as normalize_agent_type, but raises ValueError instead of silently
+    falling back to 'clutch' when the input maps to nothing recognizable.
+
+    Use at trust boundaries where an unrecognized `agentType` should surface as
+    a config error, not be papered over. Notably: user-submitted agent records
+    persisted via `save_agents` (see #54).
+
+    Legacy aliases (e.g. 'ZCode CLI', 'Claude Code CLI') are still accepted
+    exactly like in the lenient version; only genuinely unknown inputs (typos
+    like 'zcod' or made-up names) raise.
+
+    Empty / whitespace-only input still returns 'clutch' — this matches the
+    documented default when no `agentType` is specified.
+    """
+    if not raw or not raw.strip():
+        return "clutch"
+    normalized = normalize_agent_type(raw)
+    key = raw.strip().lower()
+    if normalized == "clutch" and key not in AGENT_TYPES and key not in _LEGACY_AI_ENGINE_TO_TYPE:
+        raise ValueError(
+            f"Unrecognized agentType {raw!r}. "
+            f"Expected one of {sorted(AGENT_TYPES)}, or a documented alias."
+        )
+    return normalized
+
+
 def agent_type_from_record(agent: dict[str, Any] | None) -> str:
     if not agent:
         return "clutch"

--- a/services/orchestrator/tests/test_agent_executor.py
+++ b/services/orchestrator/tests/test_agent_executor.py
@@ -312,3 +312,114 @@ def test_flow_agy_uses_hybrid_and_persists_cli_session(monkeypatch, tmp_path) ->
     assert "Output JSON only." in str(captured.get("system_prompt"))
     assert captured.get("cli_session_id") is None
     assert persisted
+
+
+# --- tool vs agentType mismatch warning (#54) ---
+
+
+def test_agent_executor_emits_warning_when_tool_disagrees_with_agent_type(monkeypatch) -> None:
+    """When the workflow node declares one tool but the referenced agent's
+    agentType is a different CLI, orchestrator dispatches by agentType (this
+    is the pre-existing behavior) but should surface a warning so users can
+    catch template-copy typos early. See #54.
+    """
+    monkeypatch.setattr(
+        "src.engine_router.find_agent",
+        lambda _ref: {
+            "id": "agent-mismatch",
+            "name": "ZCode CLI",  # user thought they cloned a ZCode agent
+            "agentType": "claude-cli",  # but forgot to change the field
+        },
+    )
+
+    captured: dict = {}
+
+    def fake_route_engine(**kwargs):
+        from src.engine_router import EngineResult
+
+        captured["kwargs"] = kwargs
+        return EngineResult(engine="Claude Code (Local CLI)", output="done", logs=[])
+
+    monkeypatch.setattr("src.engine_router.route_engine", fake_route_engine)
+
+    result = execute_agent_task(
+        {
+            "agent": "agent-mismatch",
+            "label": "step",
+            "tool": "zcode-cli",  # ← does not match agent.agentType
+            "instruction": "do a thing",
+        },
+        instruction="",
+    )
+
+    # Warning was emitted into the log stream.
+    warning_lines = [line for line in result.logs if "[ROUTER] warning" in line]
+    assert len(warning_lines) == 1
+    assert "zcode-cli" in warning_lines[0]
+    assert "claude-cli" in warning_lines[0]
+    assert "agent-mismatch" in warning_lines[0]
+
+
+def test_agent_executor_no_warning_when_tool_matches_agent_type(monkeypatch) -> None:
+    """No noise on the happy path."""
+    monkeypatch.setattr(
+        "src.engine_router.find_agent",
+        lambda _ref: {
+            "id": "agent-ok",
+            "name": "ZCode CLI",
+            "agentType": "zcode-cli",
+        },
+    )
+
+    def fake_route_engine(**kwargs):
+        from src.engine_router import EngineResult
+
+        return EngineResult(engine="ZCode CLI", output="ok", logs=[])
+
+    monkeypatch.setattr("src.engine_router.route_engine", fake_route_engine)
+
+    result = execute_agent_task(
+        {
+            "agent": "agent-ok",
+            "label": "step",
+            "tool": "zcode-cli",
+            "instruction": "do a thing",
+        },
+        instruction="",
+    )
+
+    warning_lines = [line for line in result.logs if "[ROUTER] warning" in line]
+    assert warning_lines == []
+
+
+def test_agent_executor_no_warning_when_tool_is_llm_or_empty(monkeypatch) -> None:
+    """`tool: 'llm'` or empty means 'use whatever the agent's configured
+    engine is' — no mismatch to warn about."""
+    monkeypatch.setattr(
+        "src.engine_router.find_agent",
+        lambda _ref: {
+            "id": "agent-llm",
+            "name": "Some Agent",
+            "agentType": "claude-cli",
+        },
+    )
+
+    def fake_route_engine(**kwargs):
+        from src.engine_router import EngineResult
+
+        return EngineResult(engine="Claude Code CLI", output="ok", logs=[])
+
+    monkeypatch.setattr("src.engine_router.route_engine", fake_route_engine)
+
+    for tool_value in ("llm", ""):
+        result = execute_agent_task(
+            {
+                "agent": "agent-llm",
+                "label": "step",
+                "tool": tool_value,
+                "instruction": "do a thing",
+            },
+            instruction="",
+        )
+        warning_lines = [line for line in result.logs if "[ROUTER] warning" in line]
+        assert warning_lines == [], f"unexpected warning for tool={tool_value!r}: {warning_lines}"

--- a/services/orchestrator/tests/test_agent_storage.py
+++ b/services/orchestrator/tests/test_agent_storage.py
@@ -1,0 +1,96 @@
+"""Tests for agent_storage.save_agents validation (#54)."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.agent_storage import (
+    AgentValidationError,
+    BUILTIN_AGENT_ID,
+    list_agents,
+    save_agents,
+)
+
+
+def _minimal_user_agent(**overrides):
+    base = {
+        "id": "user-agent-1",
+        "name": "Test Agent",
+        "description": "",
+        "markdownDoc": "",
+        "avatar": "",
+        "deliverables": [],
+        "mcpTools": [],
+        "mcpServerIds": [],
+        "skills": [],
+        "agentType": "claude-cli",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_save_agents_accepts_known_agent_type() -> None:
+    save_agents([_minimal_user_agent(agentType="zcode-cli")])
+    agents = list_agents()
+    saved = [a for a in agents if a.get("id") == "user-agent-1"]
+    assert len(saved) == 1
+    assert saved[0]["agentType"] == "zcode-cli"
+
+
+def test_save_agents_accepts_legacy_alias() -> None:
+    save_agents([_minimal_user_agent(agentType="ZCode CLI")])
+    agents = list_agents()
+    saved = [a for a in agents if a.get("id") == "user-agent-1"]
+    assert saved[0]["agentType"] == "zcode-cli"
+
+
+def test_save_agents_accepts_empty_agent_type_defaulting_to_clutch() -> None:
+    # An agent record without an agentType field is legal — migrate_agent_record
+    # will fall it back to 'clutch'.
+    save_agents([_minimal_user_agent(agentType="")])
+    agents = list_agents()
+    saved = [a for a in agents if a.get("id") == "user-agent-1"]
+    assert saved[0]["agentType"] == "clutch"
+
+
+def test_save_agents_rejects_unknown_agent_type() -> None:
+    """Prior behavior (#54): typo like 'zcod' silently became 'clutch' via
+    migrate_agent_record, so the persisted agent quietly routed to the
+    built-in engine instead of the CLI the user intended. Now we refuse the
+    write.
+
+    Note we use 'zcod' rather than 'zcode' — the latter is a documented legacy
+    alias that maps to 'zcode-cli' and is intentionally accepted.
+    """
+    with pytest.raises(AgentValidationError, match="invalid agentType"):
+        save_agents([_minimal_user_agent(agentType="zcod")])
+
+
+def test_save_agents_rejects_typo_with_id_in_message() -> None:
+    with pytest.raises(AgentValidationError, match="'user-agent-1'"):
+        save_agents([_minimal_user_agent(id="user-agent-1", agentType="totally-fake-cli")])
+
+
+def test_save_agents_ignores_builtin_agent_type_validation() -> None:
+    """The Clutch built-in agent always has agentType='clutch' enforced by
+    _effective_builtin(); user attempts to submit a mismatched value should
+    not error out (the value is overridden anyway)."""
+    builtin_override = {"id": BUILTIN_AGENT_ID, "name": "Clutch Agent", "agentType": "made-up"}
+    # Should not raise — builtin is filtered out of user validation.
+    save_agents([builtin_override])
+    agents = list_agents()
+    saved = [a for a in agents if a.get("id") == BUILTIN_AGENT_ID]
+    assert saved[0]["agentType"] == "clutch"
+
+
+def test_save_agents_rejects_first_bad_agent_in_batch() -> None:
+    """Validation happens before any write; a bad agent in the batch should
+    not leave the storage in a partially-updated state."""
+    with pytest.raises(AgentValidationError):
+        save_agents([
+            _minimal_user_agent(id="good-1", agentType="claude-cli"),
+            _minimal_user_agent(id="bad-1", agentType="not-a-cli"),
+        ])
+    # Neither should have been written.
+    agents = list_agents()
+    assert not any(a.get("id") in {"good-1", "bad-1"} for a in agents)

--- a/services/orchestrator/tests/test_agent_type.py
+++ b/services/orchestrator/tests/test_agent_type.py
@@ -104,3 +104,61 @@ def test_resolve_model_for_agent_ignores_session_model_for_codex_cli() -> None:
     )
     assert model_id == "agnes-image-2.1-flash"
     assert spec.id == "agnes-image-2.1-flash"
+
+
+# --- normalize_agent_type_strict tests (#54) ---
+
+
+def test_normalize_agent_type_strict_accepts_known_type() -> None:
+    from src.agent_type import normalize_agent_type_strict
+
+    assert normalize_agent_type_strict("zcode-cli") == "zcode-cli"
+    assert normalize_agent_type_strict("claude-cli") == "claude-cli"
+    assert normalize_agent_type_strict("clutch") == "clutch"
+
+
+def test_normalize_agent_type_strict_accepts_known_alias() -> None:
+    from src.agent_type import normalize_agent_type_strict
+
+    assert normalize_agent_type_strict("ZCode CLI") == "zcode-cli"
+    assert normalize_agent_type_strict("Claude Code CLI") == "claude-cli"
+
+
+def test_normalize_agent_type_strict_empty_returns_clutch() -> None:
+    from src.agent_type import normalize_agent_type_strict
+
+    assert normalize_agent_type_strict("") == "clutch"
+    assert normalize_agent_type_strict("   ") == "clutch"
+
+
+def test_normalize_agent_type_strict_raises_on_unknown() -> None:
+    """Prevent silent 'clutch' fallback on typo (#54).
+
+    'zcode' is intentionally a documented legacy alias (maps to 'zcode-cli')
+    and remains accepted; 'zcod' or 'not-a-real-cli' are genuine typos and
+    should raise so the config error surfaces early instead of silently
+    routing to the built-in Clutch engine.
+    """
+    import pytest
+    from src.agent_type import normalize_agent_type_strict
+
+    with pytest.raises(ValueError, match="Unrecognized agentType"):
+        normalize_agent_type_strict("not-a-real-cli")
+    with pytest.raises(ValueError, match="Unrecognized agentType"):
+        normalize_agent_type_strict("zcod")
+
+
+def test_normalize_agent_type_strict_still_accepts_zcode_alias() -> None:
+    """Sanity check the documented alias is not accidentally rejected."""
+    from src.agent_type import normalize_agent_type_strict
+
+    assert normalize_agent_type_strict("zcode") == "zcode-cli"
+
+
+def test_normalize_agent_type_lenient_still_falls_back() -> None:
+    """The lenient normalize_agent_type keeps its silent 'clutch' behavior
+    (relied on by tools_status and main tool_id probing). Only the *strict*
+    variant added in #54 raises."""
+    from src.agent_type import normalize_agent_type
+
+    assert normalize_agent_type("not-a-real-cli") == "clutch"


### PR DESCRIPTION
## Summary

Two silent mis-routing failure modes observed in the wild (#54) — both cause a workflow step to execute on the wrong CLI without warning:

1. **Typo in `agentType` silently becomes `'clutch'`.** `normalize_agent_type()` returns `'clutch'` for any input it can't map. That's the right behavior for internal probing paths (`tools_status.py`, `main.py` tool_id lookups), but at the trust boundary of `save_agents` it means a user writing a `'zcod'` typo persists a Clutch agent instead of getting a config error.
2. **`data.tool` and `agent.agentType` are allowed to disagree.** `execute_agent_task` correctly dispatches by `agentType`, but never checks that `agent.agentType` matches what the workflow node says its `tool` is. So a workflow node authored for `zcode-cli`, pointed at an agent whose `agentType` is `claude-cli` (e.g. a template copy where the field wasn't updated), silently executes on Claude. The log prefix uses `agent.name` and further misleads.

**Fixes #54**

## Repro trace of #54

From today's run state (`run_mrf61g2q.json`) where I was trying to test ZCode via a manually-created agent that had `agentType='claude-cli'` (template-copy typo):

```
[ROUTER] agent='agent-1783699156' matched=True agentType='claude-cli' ...
[ZCode CLI] Routing task to Claude Code (Local CLI) for agent agent-1783699156.
[ZCode CLI] Using Claude binary: /Users/interia/.local/bin/claude
```

Note the disconnect:
- Log prefix: `[ZCode CLI]` (from `agent.name`)
- Actual binary: `/Users/interia/.local/bin/claude` (from `agentType`)
- The workflow node authored `tool: 'zcode-cli'`, yet nobody complained

## Changes

### `src/agent_type.py` — new `normalize_agent_type_strict()`

Same behavior as `normalize_agent_type` for known `AGENT_TYPES` and documented `_LEGACY_AI_ENGINE_TO_TYPE` aliases, but raises `ValueError` for genuinely unknown inputs. The lenient version is preserved unchanged so `tools_status.py` and `main.py` probing paths keep working.

### `src/agent_storage.py` — validate in `save_agents`

Adds `AgentValidationError` (subclass of `ValueError`) and calls `normalize_agent_type_strict` on each user-submitted agent before writing. Validation happens **before** any file write, so a bad agent in a batch cannot leave storage partially updated. The built-in `clutch-agent` is exempt from user validation because `_effective_builtin` overwrites its `agentType` to `'clutch'` regardless.

### `src/agent_executor.py` — mismatch warning

After `find_agent(agent_ref)`, compares `normalize_agent_type(node.data.tool)` with `agent_type_from_record(agent_dict)`. If they disagree and `tool` is not `'llm'`/`''`, emits one `[ROUTER] warning: ...` log line that names both values plus the agent id/name. Execution proceeds by `agentType` — this preserves existing behavior for anyone who genuinely wants a substitution (e.g. testing a workflow against a substitute engine), but users now have a loud signal when it's actually a typo.

## Tests

New/updated tests (all in `services/orchestrator/tests/`):

- **`test_agent_type.py`** (+6): `normalize_agent_type_strict` accepts known types, accepts documented aliases, empty → `'clutch'`, raises on typo/unknown, still accepts `'zcode'` alias (regression guard), lenient version unchanged.
- **`test_agent_storage.py`** (new, +7): `save_agents` accepts known agentType, accepts legacy alias, accepts empty (defaults to clutch), rejects unknown, includes agent id in error message, ignores builtin agentType validation, is atomic across a batch.
- **`test_agent_executor.py`** (+3): mismatch emits exactly one warning, matching pair emits none, `tool='llm'` / `tool=''` emit none.

Full suite:

```
uv run pytest
================== 694 passed, 3 skipped, 1 warning in 38.77s ==================
```

Zero regressions across the entire orchestrator test suite.

## Design notes I considered and rejected

- **Refuse execution on mismatch instead of warning.** Considered but rejected — some setups may deliberately substitute engines (e.g. a Claude agent temporarily pointed at a ZCode adapter for testing). A warning surfaces the mismatch without blocking legitimate use.
- **Fix `normalize_agent_type` itself (make it strict).** Considered but rejected — multiple probing paths in `tools_status.py` and `main.py` deliberately call `normalize_agent_type(tool_id)` and rely on the `'clutch'` fallback. Changing that shape would cascade. A parallel `_strict` variant scoped to `save_agents` is the safer contract change.
- **Also update `resolve_agent_tag` to show `agentType` in the log prefix** (e.g. `[ZCode CLI → claude-cli]`). Considered but deferred — that touches all CLI adapters and log-format tests. The warning line covers the mis-routing signal for now; a follow-up PR could uniformly annotate log prefixes.

## Compatibility

- No breaking changes to public interfaces.
- `normalize_agent_type` (lenient) is unchanged.
- `save_agents` now raises `AgentValidationError` on invalid input where it previously silently corrupted the record — this is the intended behavior change and is what #54 asks for.
- Compatible with the v1.2.1 D37 sidecar-hotpatch mechanism (orchestrator-only fix, shippable as a hotpatch without a new DMG).

## Related

- **Fixes #54**
- Companion of #56 (my other open PR fixing #50 + #51). Both are orchestrator-only. They touch disjoint files and can be reviewed / merged independently in either order.
- Does not resolve #52 (Evaluator gate), #53 (file_exists check), or #55 (canvas downgrade banner) — those remain open for future work.
