### PR TITLE
feat(openspec): add OpenSpec panel to workflow sidebar [DRAFT]

### DIFF
--- a/apps/desktop/src/components/OpenSpecPanel.tsx
+++ b/apps/desktop/src/components/OpenSpecPanel.tsx
@@ -1,0 +1,185 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { fetchOpenSpecList, fetchOpenSpecStatus, type OpenSpecChange } from '../services/openspecApi';
+import { LegacyIcon } from './ui/LegacyIcon';
+
+const artifactStatusColor: Record<string, string> = {
+  ready: 'text-emerald-600 bg-emerald-50 border-emerald-200',
+  blocked: 'text-amber-600 bg-amber-50 border-amber-200',
+  pending: 'text-neutral-400 bg-neutral-50 border-neutral-200',
+};
+
+export const OpenSpecPanel: React.FC = () => {
+  const [changes, setChanges] = useState<OpenSpecChange[]>([]);
+  const [available, setAvailable] = useState<boolean | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [selectedChange, setSelectedChange] = useState<string | null>(null);
+  const [changeDetail, setChangeDetail] = useState<Record<string, unknown> | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+
+  const loadList = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const result = await fetchOpenSpecList();
+    setAvailable(result.available);
+    if (result.error) setError(result.error);
+    setChanges(result.changes || []);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void loadList();
+  }, [loadList]);
+
+  const handleSelectChange = async (name: string) => {
+    setSelectedChange(name);
+    setChangeDetail(null);
+    setDetailLoading(true);
+    const result = await fetchOpenSpecStatus(name);
+    if (result.status) setChangeDetail(result.status);
+    setDetailLoading(false);
+  };
+
+  const getArtifactStatusBadge = (status?: string) => {
+    const color = artifactStatusColor[status ?? ''] || 'text-neutral-400 bg-neutral-50 border-neutral-200';
+    return (
+      <span className={`text-[9px] font-bold px-1.5 py-0.5 rounded border ${color}`}>
+        {status ?? 'unknown'}
+      </span>
+    );
+  };
+
+  return (
+    <div className="flex flex-col h-full bg-neutral-50/30">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-neutral-100 shrink-0">
+        <div className="flex items-center gap-2">
+          <LegacyIcon name="description" className="text-[16px] text-neutral-600" />
+          <span className="text-[10px] font-bold text-neutral-500 uppercase tracking-widest">
+            OpenSpec
+          </span>
+          {available === true && (
+            <span className="text-[8px] font-bold text-emerald-600 bg-emerald-50 border border-emerald-200 rounded px-1 py-0.5">
+              CLI
+            </span>
+          )}
+          {available === false && (
+            <span className="text-[8px] font-bold text-rose-600 bg-rose-50 border border-rose-200 rounded px-1 py-0.5">
+              N/A
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => void loadList()}
+          className="text-neutral-400 hover:text-neutral-700 transition-colors p-1"
+          title="Refresh"
+        >
+          <LegacyIcon name="sync" className="text-[14px] text-neutral-400 hover:text-neutral-700 transition-colors" />
+        </button>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto p-3 space-y-2">
+        {loading && (
+          <p className="text-[10px] text-neutral-400 font-mono text-center py-4">Loading...</p>
+        )}
+
+        {!loading && available === false && (
+          <div className="text-center py-6">
+            <LegacyIcon name="info" className="text-[20px] text-neutral-300 mb-2" />
+            <p className="text-[10px] text-neutral-400 font-medium">
+              OpenSpec CLI not available
+            </p>
+            {error && (
+              <p className="text-[9px] text-neutral-400 font-mono mt-1 px-2 break-all">
+                {error}
+              </p>
+            )}
+            <p className="text-[9px] text-neutral-400 mt-2">
+              Install: <code className="text-[8px] bg-neutral-100 px-1 py-0.5 rounded">npm install -g @fission-ai/openspec</code>
+            </p>
+          </div>
+        )}
+
+        {!loading && available === true && changes.length === 0 && (
+          <div className="text-center py-6">
+            <LegacyIcon name="add_circle" className="text-[20px] text-neutral-300 mb-2" />
+            <p className="text-[10px] text-neutral-400 font-medium">
+              No changes yet
+            </p>
+            <p className="text-[9px] text-neutral-400 mt-1">
+              Run: <code className="text-[8px] bg-neutral-100 px-1 py-0.5 rounded">openspec new change &lt;name&gt;</code>
+            </p>
+          </div>
+        )}
+
+        {!loading && available === true && changes.map((ch) => {
+          const name = ch.name ?? ch.id ?? 'unnamed';
+          const isSelected = selectedChange === name;
+          const chStatus = ch.status as string | undefined;
+          return (
+            <div key={name}>
+              <button
+                type="button"
+                onClick={() => handleSelectChange(name)}
+                className={`w-full text-left p-2.5 rounded-xl border transition-all ${
+                  isSelected
+                    ? 'border-neutral-400 bg-white shadow-sm ring-1 ring-neutral-200'
+                    : 'border-neutral-200/50 bg-white hover:border-neutral-300 shadow-xs'
+                }`}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <div className="min-w-0 flex-1">
+                    <p className="text-[11px] font-bold text-neutral-800 truncate">{name}</p>
+                    <p className="text-[9px] text-neutral-400 font-mono mt-0.5">
+                      {chStatus ?? 'unknown'}
+                    </p>
+                  </div>
+                  <LegacyIcon name="chevron_right" className="text-[14px] text-neutral-300 shrink-0" />
+                </div>
+              </button>
+
+              {/* Detail panel */}
+              {isSelected && detailLoading && (
+                <div className="ml-2 mt-1 p-2 bg-neutral-50 rounded-lg border border-neutral-100">
+                  <p className="text-[9px] text-neutral-400 font-mono">Loading detail...</p>
+                </div>
+              )}
+
+              {isSelected && changeDetail && !detailLoading && (
+                <div className="ml-2 mt-1 p-2.5 bg-neutral-50 rounded-lg border border-neutral-100 space-y-1.5">
+                  <p className="text-[9px] font-bold text-neutral-600 uppercase tracking-wider">Artifacts</p>
+                  {(changeDetail.artifacts as Array<{ id: string; status: string }> | undefined)?.map((art) => (
+                    <div key={art.id} className="flex items-center justify-between text-[10px]">
+                      <span className="text-neutral-700 font-medium">{art.id}</span>
+                      {getArtifactStatusBadge(art.status)}
+                    </div>
+                  ))}
+                  {!changeDetail.artifacts && (
+                    <p className="text-[9px] text-neutral-400">No artifact detail available</p>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Footer */}
+      {available === true && (
+        <div className="px-3 py-2 border-t border-neutral-100 shrink-0">
+          <a
+            href="https://github.com/Fission-AI/OpenSpec"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1.5 text-[9px] text-neutral-400 hover:text-neutral-600 transition-colors"
+          >
+            <LegacyIcon name="bolt" className="text-[11px] text-neutral-400" />
+            OpenSpec docs
+          </a>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/components/WorkflowOrchestration.tsx
+++ b/apps/desktop/src/components/WorkflowOrchestration.tsx
@@ -26,6 +26,7 @@ import {
   formatCanvasIncompatibilities,
   getCanvasIncompatibilities,
   parseCompilerJson,
+  validWhenValues,
   type CompilerWorkflow,
 } from '../services/workflowFormat';
 import {
@@ -66,9 +67,18 @@ const MODAL_BTN_CANCEL = BTN_GHOST;
 const FLOW_DEFAULT_VIEWPORT = { x: 80, y: 60, zoom: 0.58 };
 const FLOW_FIT_VIEW_OPTIONS = { padding: 0.55, maxZoom: 0.62, minZoom: 0.2 };
 
+const nodeTypeConfig: Record<string, { icon: string; color: string; label: string; bgClass: string }> = {
+  agent_task: { icon: 'smart_toy', color: '#525252', label: 'Agent', bgClass: 'bg-neutral-100' },
+  human_gate: { icon: 'gavel', color: '#7c3aed', label: 'Approval', bgClass: 'bg-violet-50' },
+  check: { icon: 'shield_check', color: '#d97706', label: 'Check', bgClass: 'bg-amber-50' },
+};
+
 const CustomNode = ({ data }: { data: any }) => {
+  const cfg = nodeTypeConfig[data.nodeType as string] ?? nodeTypeConfig.agent_task;
   return (
-    <div className="group min-w-[220px] max-w-xs p-3 bg-white border border-neutral-300 rounded-xl shadow-sm relative hover:border-neutral-400 transition-colors">
+    <div className={`group min-w-[220px] max-w-xs p-3 bg-white border rounded-xl shadow-sm relative transition-colors`}
+      style={{ borderColor: `${cfg.color}40` }}
+    >
       <Handle 
         type="target" 
         position={Position.Top} 
@@ -77,17 +87,19 @@ const CustomNode = ({ data }: { data: any }) => {
       />
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2.5">
-          <div className="w-7 h-7 rounded-lg overflow-hidden flex-shrink-0 flex items-center justify-center bg-neutral-100">
-            {data.avatar ? (
+          <div className={`w-7 h-7 rounded-lg overflow-hidden flex-shrink-0 flex items-center justify-center ${cfg.bgClass}`}>
+            {data.avatar && data.nodeType !== 'human_gate' && data.nodeType !== 'check' ? (
               <img className="w-5 h-5 object-contain" src={data.avatar} alt={data.agent} />
             ) : (
-              <LegacyIcon name="smart_toy" className="text-[15px] text-neutral-500" />
+              <span style={{ color: cfg.color, display: 'flex' }}>
+                <LegacyIcon name={cfg.icon} className="text-[15px]" />
+              </span>
             )}
           </div>
           <div className="overflow-hidden text-left flex-1 max-w-[130px]">
             <p className="text-xs font-bold text-neutral-900 truncate">{data.name}</p>
-            <p className="text-[9px] font-medium text-neutral-400 font-mono truncate">
-              {data.agent} {data.aiTool ? `| ${data.aiTool}` : ''}
+            <p className="text-[9px] font-medium font-mono truncate" style={{ color: cfg.color }}>
+              {cfg.label}
             </p>
           </div>
         </div>
@@ -153,7 +165,8 @@ export const WorkflowOrchestration: React.FC<WorkflowOrchestrationProps> = ({
 
   // Modals state
   const [editingNodeId, setEditingNodeId] = useState<string | null>(null);
-  const [nodeForm, setNodeForm] = useState<Partial<WorkflowStep>>({});
+  const [nodeForm, setNodeForm] = useState<Partial<WorkflowStep & { fromSteps?: string[] }>>({});
+  const [showNodeTypePicker, setShowNodeTypePicker] = useState(false);
 
   // New workflow creation states
   const [isCreatingWorkflow, setIsCreatingWorkflow] = useState(false);
@@ -293,37 +306,56 @@ export const WorkflowOrchestration: React.FC<WorkflowOrchestrationProps> = ({
     if (activeWorkflow) {
       const newNodes: Node[] = activeWorkflow.steps.map((step, idx) => {
         const matchedAgent = agents.find((agent) => agent.id === step.agent || agent.name === step.agent);
+        const nodeType = step.nodeType ?? 'agent_task';
         return {
         id: step.id.toString(),
         type: 'custom',
         position: step.position || { x: 250, y: idx * 100 + 50 },
         data: {
           ...step,
+          nodeType,
           agent: resolveAgentLabel(step.agent),
-          avatar: resolveBrandLogoSrc({
+          avatar: nodeType === 'agent_task' ? resolveBrandLogoSrc({
             aiTool: step.aiTool,
             agent: matchedAgent,
             agentType: matchedAgent ? agentTypeFromAgent(matchedAgent) : undefined,
-          }),
+          }) : undefined,
           onEdit: (id: string) => openNodeEditor(id),
           onDelete: (id: string) => deleteNode(id),
         }
       };
       });
 
+      const edgeLabelStyle = { fontSize: '9px', fontWeight: 700, fill: '#fff', lineHeight: '1' };
+const edgeColors: Record<string, string> = {
+  approve: '#16a34a',
+  reject: '#dc2626',
+  retry: '#d97706',
+  passed: '#16a34a',
+  failed: '#dc2626',
+};
+
       const newEdges: Edge[] = [];
       activeWorkflow.steps.forEach(step => {
+        const edgeWhen = (step as any).edgeWhen as Record<string, string> | undefined;
         if (step.nextSteps) {
           step.nextSteps.forEach(nextId => {
+            const when = edgeWhen?.[nextId] || edgeWhen?.[nextId.toString()] || '';
+            const color = edgeColors[when] || '#a3a3a3';
             newEdges.push({
               id: `e-${step.id}-${nextId}`,
               source: step.id.toString(),
               target: nextId.toString(),
               type: 'smoothstep',
-              animated: true,
-              style: { stroke: '#a3a3a3', strokeWidth: 2 },
-              markerEnd: { type: MarkerType.ArrowClosed, color: '#a3a3a3' },
-            });
+              animated: when ? false : true,
+              style: { stroke: color, strokeWidth: when ? 2.5 : 2 },
+              markerEnd: { type: MarkerType.ArrowClosed, color },
+              label: when || undefined,
+              labelStyle: { ...edgeLabelStyle, fill: color },
+              labelBgStyle: { fill: color, borderRadius: 4, padding: '1px 4px' },
+              labelBgPadding: [4, 2] as [number, number],
+              labelBgBorderRadius: 4,
+            } as Edge);
           });
         }
       });
@@ -523,16 +555,35 @@ export const WorkflowOrchestration: React.FC<WorkflowOrchestrationProps> = ({
   };
 
   const addNode = () => {
+    setShowNodeTypePicker(true);
+  };
+
+  const createNodeOfType = (nodeType: 'agent_task' | 'human_gate' | 'check') => {
+    setShowNodeTypePicker(false);
     const newNodeId = `step-${Date.now()}`;
     setEditingNodeId(newNodeId);
-    setNodeForm({
-      name: 'New Step',
-      agent: '',
-      aiTool: '',
-      description: '',
-      nextSteps: [],
-      fromSteps: []
-    } as any);
+    if (nodeType === 'human_gate' || nodeType === 'check') {
+      setNodeForm({
+        name: nodeType === 'human_gate' ? 'Human Approval' : 'Check',
+        nodeType,
+        agent: '',
+        aiTool: '',
+        description: '',
+        nextSteps: [],
+        fromSteps: [],
+        edgeWhen: {},
+      } as any);
+    } else {
+      setNodeForm({
+        name: 'New Step',
+        nodeType: 'agent_task',
+        agent: '',
+        aiTool: '',
+        description: '',
+        nextSteps: [],
+        fromSteps: [],
+      } as any);
+    }
   };
 
   const openNodeEditor = (nodeId: string) => {
@@ -554,7 +605,8 @@ export const WorkflowOrchestration: React.FC<WorkflowOrchestrationProps> = ({
 
   const saveNode = () => {
     if (!editingNodeId) return;
-    if (!nodeForm.agent?.trim()) return;
+    const nodeType = nodeForm.nodeType ?? 'agent_task';
+    if (nodeType === 'agent_task' && !nodeForm.agent?.trim()) return;
 
     const selectedAgent = agents.find(
       (a) => a.id === nodeForm.agent || a.name === nodeForm.agent,
@@ -565,6 +617,7 @@ export const WorkflowOrchestration: React.FC<WorkflowOrchestrationProps> = ({
       
       const formFromSteps = (nodeForm as any).fromSteps || [];
       const formNextSteps = nodeForm.nextSteps || [];
+      const formEdgeWhen = (nodeForm as any).edgeWhen || {};
 
       let updatedSteps = [...wf.steps];
       const existingStepIndex = updatedSteps.findIndex(s => s.id.toString() === editingNodeId);
@@ -572,11 +625,13 @@ export const WorkflowOrchestration: React.FC<WorkflowOrchestrationProps> = ({
       const targetStep: WorkflowStep = {
         id: editingNodeId,
         name: nodeForm.name || 'New Step',
-        agent: selectedAgent?.id ?? nodeForm.agent!.trim(),
-        aiTool: nodeForm.aiTool || '',
+        nodeType,
+        agent: (nodeType === 'agent_task' ? (selectedAgent?.id ?? nodeForm.agent!.trim()) : ''),
+        aiTool: nodeType === 'agent_task' ? (nodeForm.aiTool || '') : '',
         description: nodeForm.description || '',
-        avatar: selectedAgent?.avatar || nodeForm.avatar || DEFAULT_AVATAR,
+        avatar: nodeType === 'agent_task' ? (selectedAgent?.avatar || nodeForm.avatar || DEFAULT_AVATAR) : '',
         nextSteps: formNextSteps,
+        edgeWhen: Object.keys(formEdgeWhen).length > 0 ? formEdgeWhen : undefined,
         position: nodeForm.position || (existingStepIndex >= 0 ? updatedSteps[existingStepIndex].position : { x: 250, y: wf.steps.length * 100 + 50 })
       };
 
@@ -780,14 +835,36 @@ export const WorkflowOrchestration: React.FC<WorkflowOrchestrationProps> = ({
                     </button>
                   </div>
                   {viewMode === 'canvas' && canvasCompatible && (
-                    <button
-                      type="button"
-                      onClick={addNode}
-                      className={MODAL_BTN_SECONDARY}
-                    >
-                      <LegacyIcon name="add" className="text-[16px]" />
-                      {t('Add Node')}
-                    </button>
+                    <div className="relative">
+                      <button
+                        type="button"
+                        onClick={() => setShowNodeTypePicker(!showNodeTypePicker)}
+                        className={MODAL_BTN_SECONDARY}
+                      >
+                        <LegacyIcon name="add" className="text-[16px]" />
+                        {t('Add Node')}
+                      </button>
+                      {showNodeTypePicker && (
+                        <div className="absolute right-0 top-full mt-1 z-50 bg-white border border-neutral-200 rounded-xl shadow-xl p-1.5 min-w-[160px]">
+                          {(['agent_task', 'human_gate', 'check'] as const).map((type) => {
+                            const cfg = nodeTypeConfig[type];
+                            return (
+                              <button
+                                key={type}
+                                type="button"
+                                onClick={() => createNodeOfType(type)}
+                                className="w-full flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-[11px] font-medium text-neutral-700 hover:bg-neutral-100 transition-colors text-left"
+                              >
+                                <span style={{ color: cfg.color, display: 'inline-flex' }}>
+                                <LegacyIcon name={cfg.icon} className="text-[15px]" />
+                              </span>
+                                <span>{cfg.label} Node</span>
+                              </button>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
                   )}
                   <button
                     type="button"
@@ -879,6 +956,40 @@ export const WorkflowOrchestration: React.FC<WorkflowOrchestrationProps> = ({
             </div>
             
             <div className="p-5 space-y-4 text-xs overflow-y-auto flex-1">
+              {/* Node Type Badge */}
+              <div className="space-y-1.5">
+                <label className="font-bold text-neutral-700">{t('Node Type')}</label>
+                <div className="grid grid-cols-3 gap-2">
+                  {(['agent_task', 'human_gate', 'check'] as const).map((type) => {
+                    const cfg = nodeTypeConfig[type];
+                    const isActive = (nodeForm.nodeType ?? 'agent_task') === type;
+                    return (
+                      <button
+                        key={type}
+                        type="button"
+                        onClick={() => setNodeForm({
+                          ...nodeForm,
+                          nodeType: type,
+                          name: nodeForm.name || (type === 'human_gate' ? 'Human Approval' : type === 'check' ? 'Check' : 'New Step'),
+                          agent: type === 'agent_task' ? nodeForm.agent : '',
+                          description: type === 'agent_task' ? nodeForm.description : '',
+                        })}
+                        className={`p-2 border rounded-xl flex flex-col items-center gap-1 justify-center transition-all cursor-pointer ${
+                          isActive
+                            ? 'border-neutral-800 bg-neutral-900 text-white'
+                            : 'border-neutral-200 hover:border-neutral-350 text-neutral-600 bg-neutral-50/50'
+                        }`}
+                      >
+                        <span style={{ color: isActive ? '#fff' : cfg.color, display: 'inline-flex' }}>
+                          <LegacyIcon name={cfg.icon} className="text-[16px]" />
+                        </span>
+                        <span className="text-[9px] font-bold leading-tight">{cfg.label}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
               <div className="space-y-1.5">
                 <label className="font-bold text-neutral-700">{t('Node Name')}</label>
                 <input 
@@ -886,10 +997,12 @@ export const WorkflowOrchestration: React.FC<WorkflowOrchestrationProps> = ({
                   value={nodeForm.name || ''}
                   onChange={e => setNodeForm({...nodeForm, name: e.target.value})}
                   className="w-full border border-neutral-200 rounded-lg px-3 py-2 text-xs focus:outline-none focus:border-neutral-400 focus:ring-2 focus:ring-neutral-200/50 transition-all font-medium"
-                  placeholder={t('e.g. Asset Gathering')}
+                  placeholder={nodeForm.nodeType === 'human_gate' ? t('e.g. Review & Approve') : nodeForm.nodeType === 'check' ? t('e.g. Verify File Exists') : t('e.g. Asset Gathering')}
                 />
               </div>
 
+              {/* Agent selector — only for agent_task */}
+              {(nodeForm.nodeType ?? 'agent_task') === 'agent_task' && (
               <div className="space-y-1.5">
                 <label className="font-bold text-neutral-700">{t('Assigned Agent')}</label>
                 <select 
@@ -937,14 +1050,18 @@ export const WorkflowOrchestration: React.FC<WorkflowOrchestrationProps> = ({
                   </div>
                 )}
               </div>
+              )}
 
+              {/* Description/Instructions — for agent_task and gate (label display) */}
               <div className="space-y-1.5">
-                <label className="font-bold text-neutral-700">{t('Description / Instructions')}</label>
+                <label className="font-bold text-neutral-700">
+                  {(nodeForm.nodeType ?? 'agent_task') === 'agent_task' ? t('Description / Instructions') : t('Label / Prompt')}
+                </label>
                 <textarea 
                   value={nodeForm.description || ''}
                   onChange={e => setNodeForm({...nodeForm, description: e.target.value})}
                   className="w-full border border-neutral-200 rounded-lg px-3 py-2 text-xs focus:outline-none focus:border-neutral-400 focus:ring-2 focus:ring-neutral-200/50 transition-all min-h-[80px] resize-none"
-                  placeholder={t('Task instructions...')}
+                  placeholder={nodeForm.nodeType === 'human_gate' ? t('What to ask the human to review...') : nodeForm.nodeType === 'check' ? t('What to verify...') : t('Task instructions...')}
                 />
               </div>
 
@@ -996,9 +1113,13 @@ export const WorkflowOrchestration: React.FC<WorkflowOrchestrationProps> = ({
                     {activeWorkflow?.steps
                       .filter(s => s.id.toString() !== editingNodeId)
                       .map(s => {
+                        const nodeType = nodeForm.nodeType ?? 'agent_task';
                         const isConnected = (nodeForm.nextSteps || []).includes(s.id.toString());
+                        const whenValues = validWhenValues(nodeType);
+                        const edgeWhen = (nodeForm as any).edgeWhen || {};
+                        const currentWhen = edgeWhen[s.id.toString()] || '';
                         return (
-                          <label key={s.id} className="flex items-center gap-2 cursor-pointer hover:text-neutral-900 leading-none select-none py-0.5">
+                          <div key={s.id} className="flex items-center gap-2 py-0.5">
                             <input 
                               type="checkbox"
                               checked={isConnected}
@@ -1006,15 +1127,17 @@ export const WorkflowOrchestration: React.FC<WorkflowOrchestrationProps> = ({
                                 const checked = e.target.checked;
                                 setNodeForm(prev => {
                                   const currentNext = prev.nextSteps || [];
+                                  const currentEdgeWhen = { ...((prev as any).edgeWhen || {}) };
                                   const updatedNext = checked 
                                     ? [...currentNext, s.id.toString()]
                                     : currentNext.filter(id => id !== s.id.toString());
-                                  return { ...prev, nextSteps: updatedNext };
+                                  if (!checked) delete currentEdgeWhen[s.id.toString()];
+                                  return { ...prev, nextSteps: updatedNext, edgeWhen: currentEdgeWhen };
                                 });
                               }}
                               className="rounded border-neutral-300 text-neutral-800 focus:ring-neutral-400 w-3.5 h-3.5"
                             />
-                            <span className="text-[11px] truncate font-medium text-neutral-700">
+                            <span className="text-[11px] truncate font-medium text-neutral-700 flex-1">
                               {s.name}{' '}
                               {s.agent ? (
                                 <span className="text-[9px] text-neutral-400 font-normal">
@@ -1022,7 +1145,30 @@ export const WorkflowOrchestration: React.FC<WorkflowOrchestrationProps> = ({
                                 </span>
                               ) : null}
                             </span>
-                          </label>
+                            {isConnected && whenValues.length > 0 && (
+                              <select
+                                value={currentWhen}
+                                onChange={(e) => {
+                                  setNodeForm(prev => {
+                                    const currentEdgeWhen = { ...((prev as any).edgeWhen || {}) };
+                                    if (e.target.value) {
+                                      currentEdgeWhen[s.id.toString()] = e.target.value;
+                                    } else {
+                                      delete currentEdgeWhen[s.id.toString()];
+                                    }
+                                    return { ...prev, edgeWhen: currentEdgeWhen };
+                                  });
+                                }}
+                                className="text-[9px] border border-neutral-200 rounded px-1.5 py-0.5 bg-white font-mono"
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                <option value="">{t('unconditional')}</option>
+                                {whenValues.map((wv) => (
+                                  <option key={wv} value={wv}>{wv}</option>
+                                ))}
+                              </select>
+                            )}
+                          </div>
                         );
                       })}
                     {(activeWorkflow?.steps || []).filter(s => s.id.toString() !== editingNodeId).length === 0 && (
@@ -1048,7 +1194,7 @@ export const WorkflowOrchestration: React.FC<WorkflowOrchestrationProps> = ({
               <button
                 type="button"
                 onClick={saveNode}
-                disabled={!nodeForm.agent?.trim()}
+                disabled={(nodeForm.nodeType ?? 'agent_task') === 'agent_task' && !nodeForm.agent?.trim()}
                 className={MODAL_BTN_PRIMARY}
               >
                 {t('Save Node')}

--- a/apps/desktop/src/components/WorkflowOrchestration.tsx
+++ b/apps/desktop/src/components/WorkflowOrchestration.tsx
@@ -19,6 +19,7 @@ import {
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import { WorkflowJsonPanel } from './WorkflowJsonPanel';
+import { OpenSpecPanel } from './OpenSpecPanel';
 import {
   canvasToCompiler,
   compilerToCanvas,
@@ -47,6 +48,7 @@ import { LegacyIcon } from './ui/LegacyIcon';
 import { FullscreenModalOverlay } from './ui/FullscreenModalOverlay';
 
 type EditorViewMode = 'canvas' | 'json';
+type SidebarTab = 'workflows' | 'openspec';
 
 interface WorkflowOrchestrationProps {
   onClose: () => void;
@@ -149,6 +151,7 @@ export const WorkflowOrchestration: React.FC<WorkflowOrchestrationProps> = ({
   const [workflows, setWorkflows] = useState<WorkflowDef[]>([]);
   const [activeWorkflowId, setActiveWorkflowId] = useState<string>('');
   const [viewMode, setViewMode] = useState<EditorViewMode>('canvas');
+  const [sidebarTab, setSidebarTab] = useState<SidebarTab>('workflows');
   const [jsonText, setJsonText] = useState('');
   const [canvasCompatible, setCanvasCompatible] = useState(false);
   const [canvasIncompatHint, setCanvasIncompatHint] = useState<string | null>(null);
@@ -721,11 +724,42 @@ const edgeColors: Record<string, string> = {
       </div>
 
       <div className="flex flex-1 min-h-0">
-        {/* Left sidebar for workflows */}
-        <div className="w-[280px] border-r border-neutral-100 bg-neutral-50/30 overflow-y-auto flex flex-col p-4 gap-3 overflow-x-hidden">
-          <h3 className="text-[10px] font-bold text-neutral-400 uppercase tracking-widest pl-2 mb-1 text-left">
-            {t('Active SOP Workflows')}
-          </h3>
+        {/* Left sidebar with tabs */}
+        <div className="w-[280px] border-r border-neutral-100 bg-neutral-50/30 flex flex-col overflow-hidden">
+          {/* Tab switcher */}
+          <div className="flex border-b border-neutral-200/60 shrink-0">
+            <button
+              type="button"
+              onClick={() => setSidebarTab('workflows')}
+              className={`flex-1 py-2 text-[10px] font-bold uppercase tracking-widest text-center transition-colors ${
+                sidebarTab === 'workflows'
+                  ? 'text-neutral-800 bg-white border-b-2 border-neutral-800'
+                  : 'text-neutral-400 hover:text-neutral-600'
+              }`}
+            >
+              <LegacyIcon name="account_tree" className="text-[12px] inline mr-1" />
+              Workflows
+            </button>
+            <button
+              type="button"
+              onClick={() => setSidebarTab('openspec')}
+              className={`flex-1 py-2 text-[10px] font-bold uppercase tracking-widest text-center transition-colors ${
+                sidebarTab === 'openspec'
+                  ? 'text-neutral-800 bg-white border-b-2 border-neutral-800'
+                  : 'text-neutral-400 hover:text-neutral-600'
+              }`}
+            >
+              <LegacyIcon name="description" className="text-[12px] inline mr-1" />
+              OpenSpec
+            </button>
+          </div>
+
+          {/* Tab content */}
+          {sidebarTab === 'workflows' ? (
+          <div className="flex-1 overflow-y-auto flex flex-col p-4 gap-3 overflow-x-hidden">
+            <h3 className="text-[10px] font-bold text-neutral-400 uppercase tracking-widest pl-2 mb-1 text-left">
+              {t('Active SOP Workflows')}
+            </h3>
           {loading && (
             <p className="text-[10px] text-neutral-400 pl-2 font-mono">{t('Loading...')}</p>
           )}
@@ -787,6 +821,12 @@ const edgeColors: Record<string, string> = {
             </div>
             );
           })}
+        </div>
+        ) : (
+          <div className="flex-1 overflow-hidden">
+            <OpenSpecPanel />
+          </div>
+        )}
         </div>
 
         <div className="flex-1 flex flex-col relative min-h-0">

--- a/apps/desktop/src/services/openspecApi.ts
+++ b/apps/desktop/src/services/openspecApi.ts
@@ -1,0 +1,42 @@
+/** OpenSpec CLI integration via Sidecar. */
+
+import { SIDECAR_BASE as BASE, sidecarFetch } from './sidecarUrl';
+
+export interface OpenSpecChange {
+  name?: string;
+  id?: string;
+  status?: string;
+  [key: string]: unknown;
+}
+
+export interface OpenSpecListResponse {
+  available: boolean;
+  error?: string;
+  changes: OpenSpecChange[];
+}
+
+export interface OpenSpecStatusResponse {
+  available: boolean;
+  error?: string;
+  status?: Record<string, unknown>;
+}
+
+export async function fetchOpenSpecList(): Promise<OpenSpecListResponse> {
+  try {
+    const res = await sidecarFetch(`${BASE}/api/openspec/list`);
+    if (!res.ok) return { available: false, error: `HTTP ${res.status}`, changes: [] };
+    return (await res.json()) as OpenSpecListResponse;
+  } catch (err) {
+    return { available: false, error: err instanceof Error ? err.message : String(err), changes: [] };
+  }
+}
+
+export async function fetchOpenSpecStatus(change: string): Promise<OpenSpecStatusResponse> {
+  try {
+    const res = await sidecarFetch(`${BASE}/api/openspec/status?change=${encodeURIComponent(change)}`);
+    if (!res.ok) return { available: false, error: `HTTP ${res.status}` };
+    return (await res.json()) as OpenSpecStatusResponse;
+  } catch (err) {
+    return { available: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/apps/desktop/src/services/workflowFormat.test.ts
+++ b/apps/desktop/src/services/workflowFormat.test.ts
@@ -3,6 +3,9 @@ import {
   formatCanvasIncompatibilities,
   getCanvasIncompatibilities,
   isCanvasCompatible,
+  canvasToCompiler,
+  compilerToCanvas,
+  validWhenValues,
 } from '../services/workflowFormat';
 
 describe('workflowFormat', () => {
@@ -29,7 +32,7 @@ describe('workflowFormat', () => {
     expect(isCanvasCompatible(workflow)).toBe(true);
   });
 
-  it('lists human_gate and conditional edges as canvas incompatibilities (#55)', () => {
+  it('accepts human_gate with conditional edges as canvas compatible', () => {
     const workflow = {
       nodes: [
         { id: 'builder', type: 'agent_task' },
@@ -44,32 +47,11 @@ describe('workflowFormat', () => {
       ],
     };
     const reasons = getCanvasIncompatibilities(workflow);
-    expect(isCanvasCompatible(workflow)).toBe(false);
-    expect(reasons).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          kind: 'unsupported_node_type',
-          nodeId: 'review-gate',
-          nodeType: 'human_gate',
-        }),
-        expect.objectContaining({
-          kind: 'conditional_edge',
-          edgeId: 'e5',
-          when: 'reject',
-        }),
-        expect.objectContaining({
-          kind: 'branching_node',
-          nodeId: 'review-gate',
-        }),
-      ]),
-    );
-    const summary = formatCanvasIncompatibilities(reasons);
-    expect(summary).toContain('review-gate');
-    expect(summary).toContain('human_gate');
-    expect(summary).toContain('e5');
+    expect(isCanvasCompatible(workflow)).toBe(true);
+    expect(reasons).toEqual([]);
   });
 
-  it('lists check nodes as unsupported for canvas', () => {
+  it('accepts check nodes with passed/failed edges as canvas compatible', () => {
     const workflow = {
       nodes: [
         { id: 'n1', type: 'agent_task' },
@@ -83,8 +65,125 @@ describe('workflowFormat', () => {
       ],
     };
     const reasons = getCanvasIncompatibilities(workflow);
-    expect(reasons.some((r) => r.kind === 'unsupported_node_type' && r.nodeId === 'verify')).toBe(
-      true,
-    );
+    expect(isCanvasCompatible(workflow)).toBe(true);
+    expect(reasons).toEqual([]);
+  });
+
+  it('rejects conditional edges on agent_task nodes (not gate/check)', () => {
+    const workflow = {
+      nodes: [
+        { id: 'n1', type: 'agent_task' },
+        { id: 'end', type: 'end' },
+      ],
+      edges: [
+        { id: 'e1', source: 'start', target: 'n1' },
+        { id: 'e2', source: 'n1', target: 'end', data: { when: 'passed' } },
+      ],
+    };
+    const reasons = getCanvasIncompatibilities(workflow);
+    expect(isCanvasCompatible(workflow)).toBe(false);
+    expect(reasons.some((r) => r.kind === 'conditional_edge_on_linear')).toBe(true);
+  });
+
+  it('rejects excessive branching (>3) on human_gate', () => {
+    const workflow = {
+      nodes: [
+        { id: 'gate', type: 'human_gate' },
+        { id: 'a', type: 'agent_task' },
+        { id: 'b', type: 'agent_task' },
+        { id: 'c', type: 'agent_task' },
+        { id: 'd', type: 'agent_task' },
+        { id: 'end', type: 'end' },
+      ],
+      edges: [
+        { id: 'e1', source: 'start', target: 'gate' },
+        { id: 'e2', source: 'gate', target: 'a', data: { when: 'approve' } },
+        { id: 'e3', source: 'gate', target: 'b', data: { when: 'reject' } },
+        { id: 'e4', source: 'gate', target: 'c', data: { when: 'retry' } },
+        { id: 'e5', source: 'gate', target: 'd', data: { when: 'approve' } }, // 4th — exceeds 3
+        { id: 'e6', source: 'a', target: 'end' },
+        { id: 'e7', source: 'b', target: 'end' },
+        { id: 'e8', source: 'c', target: 'end' },
+        { id: 'e9', source: 'd', target: 'end' },
+      ],
+    };
+    const reasons = getCanvasIncompatibilities(workflow);
+    expect(reasons.some((r) => r.kind === 'excessive_branching')).toBe(true);
+  });
+
+  it('rejects unsupported node types', () => {
+    const workflow = {
+      nodes: [
+        { id: 'n1', type: 'agent_task' },
+        { id: 'unknown', type: 'not_a_type' },
+        { id: 'end', type: 'end' },
+      ],
+      edges: [
+        { id: 'e1', source: 'start', target: 'n1' },
+        { id: 'e2', source: 'n1', target: 'unknown' },
+        { id: 'e3', source: 'unknown', target: 'end' },
+      ],
+    };
+    const reasons = getCanvasIncompatibilities(workflow);
+    expect(reasons.some((r) => r.kind === 'unsupported_node_type')).toBe(true);
+  });
+
+  it('compilerToCanvas preserves human_gate node type', () => {
+    const workflow = {
+      id: 'test',
+      name: 'Test',
+      version: 1,
+      nodes: [
+        { id: 'write', type: 'agent_task', data: { label: 'Write', agent: 'a1', instruction: 'Write something' } },
+        { id: 'review', type: 'human_gate', data: { label: 'Review' } },
+        { id: 'end', type: 'end', data: { label: 'Finish' } },
+      ],
+      edges: [
+        { id: 'e1', source: 'start', target: 'write' },
+        { id: 'e2', source: 'write', target: 'review' },
+        { id: 'e3', source: 'review', target: 'end', data: { when: 'approve' } },
+        { id: 'e4', source: 'review', target: 'write', data: { when: 'reject' } },
+      ],
+    };
+    const canvas = compilerToCanvas(workflow);
+    expect(canvas.steps).toHaveLength(2);
+    const gateStep = canvas.steps.find((s) => s.id === 'review');
+    expect(gateStep).toBeDefined();
+    expect(gateStep!.nodeType).toBe('human_gate');
+    expect(gateStep!.edgeWhen).toBeDefined();
+    expect(gateStep!.edgeWhen!['end']).toBe('approve');
+    expect(gateStep!.edgeWhen!['write']).toBe('reject');
+  });
+
+  it('canvasToCompiler produces human_gate nodes with conditional edges', () => {
+    const canvas = {
+      id: 'test',
+      name: 'Test',
+      lastDeployed: '—',
+      isActive: false,
+      icon: 'fork_right',
+      steps: [
+        { id: 'write', name: 'Write', nodeType: 'agent_task' as const, agent: 'a1', description: 'Write things', nextSteps: ['review'] },
+        { id: 'review', name: 'Review Content', nodeType: 'human_gate' as const, agent: '', description: '', nextSteps: ['end', 'write'], edgeWhen: { end: 'approve' as const, write: 'reject' as const } },
+      ],
+      description: '',
+    };
+    const compiler = canvasToCompiler(canvas);
+    const gateNode = compiler.nodes.find((n) => n.id === 'review');
+    expect(gateNode).toBeDefined();
+    expect(gateNode!.type).toBe('human_gate');
+    const approveEdge = compiler.edges.find((e) => e.source === 'review' && e.target === 'end');
+    expect(approveEdge).toBeDefined();
+    expect(approveEdge!.data?.when).toBe('approve');
+    const rejectEdge = compiler.edges.find((e) => e.source === 'review' && e.target === 'write');
+    expect(rejectEdge).toBeDefined();
+    expect(rejectEdge!.data?.when).toBe('reject');
+  });
+
+  it('validWhenValues returns correct values for each node type', () => {
+    expect(validWhenValues('human_gate')).toEqual(['approve', 'reject', 'retry']);
+    expect(validWhenValues('check')).toEqual(['passed', 'failed']);
+    expect(validWhenValues('agent_task')).toEqual([]);
+    expect(validWhenValues(undefined)).toEqual([]);
   });
 });

--- a/apps/desktop/src/services/workflowFormat.ts
+++ b/apps/desktop/src/services/workflowFormat.ts
@@ -1,6 +1,12 @@
-/** Canvas ↔ compiler JSON mapping (D9). Simple linear agent_task chains only. */
+/**
+ * Canvas ↔ compiler JSON mapping.
+ *
+ * Supported on the visual canvas: agent_task, human_gate, check, end.
+ * human_gate/check nodes may have up to 3 outgoing edges with `when` values
+ * (approve/reject/retry for gates; passed/failed for checks).
+ */
 
-import type { WorkflowDef, WorkflowStep } from '../types';
+import type { WorkflowDef, WorkflowStep, EdgeWhen } from '../types';
 
 export interface CompilerNode {
   id: string;
@@ -26,13 +32,25 @@ export interface CompilerWorkflow {
   description?: string;
 }
 
+/** Node types renderable on the canvas (everything except virtual start). */
+const CANVAS_NODE_TYPES = new Set(['agent_task', 'human_gate', 'check', 'end']);
+
+/** Valid `when` values for edges leaving human_gate nodes. */
+const GATE_WHEN_VALUES = new Set<EdgeWhen>(['approve', 'reject', 'retry']);
+/** Valid `when` values for edges leaving check nodes. */
+const CHECK_WHEN_VALUES = new Set<EdgeWhen>(['passed', 'failed']);
+/** Maximum outgoing edges from a branching node (gate/check). */
+const MAX_BRANCH_OUT = 3;
+
 export type CanvasIncompatibility =
   | { kind: 'multiple_end_nodes'; count: number }
   | { kind: 'unsupported_node_type'; nodeId: string; nodeType: string }
   | { kind: 'conditional_edge'; edgeId: string; source: string; target: string; when: string }
+  | { kind: 'conditional_edge_on_linear'; edgeId: string; source: string; target: string; when: string }
   | { kind: 'invalid_start'; outDegree: number }
   | { kind: 'invalid_end'; nodeId: string; inDegree: number }
   | { kind: 'branching_node'; nodeId: string; outDegree: number }
+  | { kind: 'excessive_branching'; nodeId: string; outDegree: number; nodeType: string }
   | { kind: 'merge_or_cycle'; nodeId: string; inDegree: number }
   | { kind: 'isolated_node'; nodeId: string };
 
@@ -44,7 +62,7 @@ function slugId(name: string): string {
   return base || `step-${Date.now()}`;
 }
 
-/** Collect every reason the canvas editor cannot host this workflow (D9). */
+/** Collect every reason the canvas editor cannot host this workflow. */
 export function getCanvasIncompatibilities(
   workflow: Pick<CompilerWorkflow, 'nodes' | 'edges'>,
 ): CanvasIncompatibility[] {
@@ -54,24 +72,14 @@ export function getCanvasIncompatibilities(
     reasons.push({ kind: 'multiple_end_nodes', count: endNodes.length });
   }
 
+  const nodeMap = new Map(workflow.nodes.map((n) => [n.id, n]));
+
   for (const node of workflow.nodes) {
-    if (node.type !== 'agent_task' && node.type !== 'end') {
+    if (!CANVAS_NODE_TYPES.has(node.type)) {
       reasons.push({
         kind: 'unsupported_node_type',
         nodeId: node.id,
         nodeType: node.type,
-      });
-    }
-  }
-
-  for (const edge of workflow.edges) {
-    if (edge.data?.when) {
-      reasons.push({
-        kind: 'conditional_edge',
-        edgeId: edge.id,
-        source: edge.source,
-        target: edge.target,
-        when: String(edge.data.when),
       });
     }
   }
@@ -86,6 +94,23 @@ export function getCanvasIncompatibilities(
   const startOut = outCount.start ?? 0;
   if (startOut !== 1) {
     reasons.push({ kind: 'invalid_start', outDegree: startOut });
+  }
+
+  // Validate conditional edges
+  for (const edge of workflow.edges) {
+    if (!edge.data?.when) continue;
+    const sourceNode = nodeMap.get(edge.source);
+    if (!sourceNode) continue;
+    if (sourceNode.type === 'human_gate' && GATE_WHEN_VALUES.has(edge.data.when as EdgeWhen)) continue;
+    if (sourceNode.type === 'check' && CHECK_WHEN_VALUES.has(edge.data.when as EdgeWhen)) continue;
+    // Conditional edge on a linear node (agent_task) — invalid
+    reasons.push({
+      kind: 'conditional_edge_on_linear',
+      edgeId: edge.id,
+      source: edge.source,
+      target: edge.target,
+      when: String(edge.data.when),
+    });
   }
 
   const agentNodes = workflow.nodes.filter((n) => n.type === 'agent_task');
@@ -107,13 +132,29 @@ export function getCanvasIncompatibilities(
       }
       continue;
     }
+    if (node.type === 'start') continue;
     const out = outCount[node.id] ?? 0;
     const inc = inCount[node.id] ?? 0;
-    if (out > 1) {
-      reasons.push({ kind: 'branching_node', nodeId: node.id, outDegree: out });
+    const isGate = node.type === 'human_gate' || node.type === 'check';
+    if (isGate) {
+      if (out > MAX_BRANCH_OUT) {
+        reasons.push({ kind: 'excessive_branching', nodeId: node.id, outDegree: out, nodeType: node.type });
+      }
+    } else {
+      if (out > 1) {
+        reasons.push({ kind: 'branching_node', nodeId: node.id, outDegree: out });
+      }
     }
+    // Allow merges when the extra incoming edge is from a human_gate/check (loopback)
     if (inc > 1) {
-      reasons.push({ kind: 'merge_or_cycle', nodeId: node.id, inDegree: inc });
+      const incomingEdges = workflow.edges.filter((e) => e.target === node.id);
+      const nonGateIncoming = incomingEdges.filter((e) => {
+        const src = nodeMap.get(e.source);
+        return src && src.type !== 'human_gate' && src.type !== 'check';
+      });
+      if (nonGateIncoming.length > 1) {
+        reasons.push({ kind: 'merge_or_cycle', nodeId: node.id, inDegree: inc });
+      }
     }
     if (out === 0 && inc === 0) {
       reasons.push({ kind: 'isolated_node', nodeId: node.id });
@@ -133,6 +174,7 @@ export function formatCanvasIncompatibilities(reasons: CanvasIncompatibility[]):
         case 'unsupported_node_type':
           return `node ${r.nodeId} (${r.nodeType})`;
         case 'conditional_edge':
+        case 'conditional_edge_on_linear':
           return `edge ${r.edgeId} ${r.source}→${r.target} (when:${r.when})`;
         case 'invalid_start':
           return `start out-degree ${r.outDegree} (need 1)`;
@@ -140,6 +182,8 @@ export function formatCanvasIncompatibilities(reasons: CanvasIncompatibility[]):
           return `end ${r.nodeId} in-degree ${r.inDegree} (need 1)`;
         case 'branching_node':
           return `node ${r.nodeId} branches (out:${r.outDegree})`;
+        case 'excessive_branching':
+          return `node ${r.nodeId} (${r.nodeType}) has ${r.outDegree} outgoing (max ${MAX_BRANCH_OUT})`;
         case 'merge_or_cycle':
           return `node ${r.nodeId} merge/cycle (in:${r.inDegree})`;
         case 'isolated_node':
@@ -151,15 +195,24 @@ export function formatCanvasIncompatibilities(reasons: CanvasIncompatibility[]):
     .join('; ');
 }
 
-/** True when workflow is a simple linear agent_task pipeline (canvas-safe). */
+/** True when workflow can be hosted on the visual canvas. */
 export function isCanvasCompatible(workflow: Pick<CompilerWorkflow, 'nodes' | 'edges'>): boolean {
   return getCanvasIncompatibilities(workflow).length === 0;
 }
 
-export function compilerToCanvas(workflow: CompilerWorkflow, icon = 'account_tree'): WorkflowDef {
-  const agentNodes = workflow.nodes.filter((n) => n.type === 'agent_task');
+/** Valid `when` values for a given node type. */
+export function validWhenValues(nodeType: string | undefined): EdgeWhen[] {
+  if (nodeType === 'human_gate') return ['approve', 'reject', 'retry'];
+  if (nodeType === 'check') return ['passed', 'failed'];
+  return [];
+}
 
-  const steps: WorkflowStep[] = agentNodes.map((node) => {
+export function compilerToCanvas(workflow: CompilerWorkflow, icon = 'account_tree'): WorkflowDef {
+  const canvasNodes = workflow.nodes.filter((n) => CANVAS_NODE_TYPES.has(n.type) && n.type !== 'end');
+
+  const nodeTypeMap = new Map(workflow.nodes.map((n) => [n.id, n.type]));
+
+  const steps: WorkflowStep[] = canvasNodes.map((node) => {
     const data = node.data as {
       label?: string;
       agent?: string;
@@ -168,13 +221,26 @@ export function compilerToCanvas(workflow: CompilerWorkflow, icon = 'account_tre
     };
     const incoming = workflow.edges.filter((e) => e.target === node.id);
     const outgoing = workflow.edges.filter((e) => e.source === node.id);
+
+    // Collect edge `when` values for conditional routing
+    const edgeWhen: Record<string, EdgeWhen> = {};
+    for (const e of outgoing) {
+      if (e.data?.when) {
+        edgeWhen[e.target] = e.data.when as EdgeWhen;
+      }
+    }
+
+    const nodeType = (node.type === 'human_gate' || node.type === 'check') ? node.type : 'agent_task';
+
     return {
       id: node.id,
       name: data.label ?? node.id,
+      nodeType,
       agent: data.agent ?? '',
       aiTool: data.tool,
       description: data.instruction ?? '',
       nextSteps: outgoing.map((e) => e.target).filter((t) => t !== 'end'),
+      edgeWhen: Object.keys(edgeWhen).length > 0 ? edgeWhen : undefined,
       position: node.position,
       fromSteps: incoming.map((e) => e.source).filter((s) => s !== 'start'),
     } as WorkflowStep & { fromSteps?: string[] };
@@ -195,17 +261,33 @@ export function canvasToCompiler(
   canvas: WorkflowDef,
   base?: Partial<CompilerWorkflow>,
 ): CompilerWorkflow {
-  const agentNodes: CompilerNode[] = canvas.steps.map((step, idx) => ({
-    id: String(step.id),
-    type: 'agent_task',
-    position: step.position ?? { x: 250, y: idx * 120 + 80 },
-    data: {
-      label: step.name,
-      agent: step.agent,
-      ...(step.aiTool ? { tool: step.aiTool } : {}),
-      instruction: step.description || step.name,
-    },
-  }));
+  const compilerNodes: CompilerNode[] = canvas.steps.map((step, idx) => {
+    const nodeType = step.nodeType ?? 'agent_task';
+    const position = step.position ?? { x: 250, y: idx * 120 + 80 };
+
+    if (nodeType === 'human_gate' || nodeType === 'check') {
+      return {
+        id: String(step.id),
+        type: nodeType,
+        position,
+        data: {
+          label: step.name || (nodeType === 'human_gate' ? 'Human Approval' : 'Check'),
+        },
+      };
+    }
+
+    return {
+      id: String(step.id),
+      type: 'agent_task',
+      position,
+      data: {
+        label: step.name,
+        agent: step.agent,
+        ...(step.aiTool ? { tool: step.aiTool } : {}),
+        instruction: step.description || step.name,
+      },
+    };
+  });
 
   const endNode: CompilerNode = {
     id: 'end',
@@ -218,41 +300,52 @@ export function canvasToCompiler(
   let edgeIdx = 1;
 
   if (canvas.steps.length === 0) {
-    edges.push({
-      id: `e${edgeIdx++}`,
-      source: 'start',
-      target: 'end',
-    });
+    edges.push({ id: `e${edgeIdx++}`, source: 'start', target: 'end' });
   } else {
-    edges.push({
-      id: `e${edgeIdx++}`,
-      source: 'start',
-      target: String(canvas.steps[0].id),
-    });
+    edges.push({ id: `e${edgeIdx++}`, source: 'start', target: String(canvas.steps[0].id) });
   }
+
+  // Build a set of all node ids for quick lookup
+  const stepIds = new Set(canvas.steps.map((s) => String(s.id)));
+  const nodeTypeById = new Map(canvas.steps.map((s) => [String(s.id), s.nodeType ?? 'agent_task']));
 
   for (const step of canvas.steps) {
     const targets = step.nextSteps?.length
       ? step.nextSteps
-      : canvas.steps.findIndex((s) => s.id === step.id) === canvas.steps.length - 1
-        ? ['end']
-        : [];
+      : [];
+    const nodeType = step.nodeType ?? 'agent_task';
+    const edgeWhen = (step as any).edgeWhen as Record<string, EdgeWhen> | undefined;
+
     for (const target of targets) {
-      edges.push({
+      const targetId = target === 'end' ? 'end' : String(target);
+      const edge: CompilerEdge = {
         id: `e${edgeIdx++}`,
         source: String(step.id),
-        target: target === 'end' ? 'end' : String(target),
-      });
+        target: targetId,
+      };
+      // Add conditional when for gate/check nodes
+      if (edgeWhen && edgeWhen[targetId]) {
+        edge.data = { when: edgeWhen[targetId] };
+      } else if (edgeWhen && edgeWhen[target]) {
+        edge.data = { when: edgeWhen[target] };
+      }
+      edges.push(edge);
     }
   }
 
+  // Ensure end is reachable: if no edges point to end yet, connect the last agent_task
+  // or the last branching node without explicit nextSteps to end.
   if (!edges.some((e) => e.target === 'end') && canvas.steps.length > 0) {
-    const last = canvas.steps[canvas.steps.length - 1];
-    edges.push({
-      id: `e${edgeIdx++}`,
-      source: String(last.id),
-      target: 'end',
-    });
+    // Find nodes that have no outgoing edges
+    const sourcesWithEdges = new Set(edges.map((e) => e.source));
+    const terminalSteps = canvas.steps.filter((s) => !sourcesWithEdges.has(String(s.id)));
+    for (const step of terminalSteps) {
+      edges.push({
+        id: `e${edgeIdx++}`,
+        source: String(step.id),
+        target: 'end',
+      });
+    }
   }
 
   const rawId = canvas.id || slugId(canvas.name);
@@ -262,7 +355,7 @@ export function canvasToCompiler(
     id,
     name: canvas.name,
     version: base?.version ?? 1,
-    nodes: [...agentNodes, endNode],
+    nodes: [...compilerNodes, endNode],
     edges,
     icon: canvas.icon,
     description: canvas.description,

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -24,7 +24,9 @@ export type {
   WebSocketEnvelope,
   WebSocketEvent,
   WorkflowDef,
+  WorkflowNodeType,
   WorkflowStep,
+  EdgeWhen,
 } from '@clutch/shared-types';
 
 export interface Deliverable {

--- a/packages/shared-types/index.ts
+++ b/packages/shared-types/index.ts
@@ -45,14 +45,25 @@ export interface ChatMessage {
   };
 }
 
+/** Supported node types in the visual canvas editor. */
+export type WorkflowNodeType = 'agent_task' | 'human_gate' | 'check';
+
+/** Conditional routing value on edges (set by check/human_gate nodes). */
+export type EdgeWhen = 'approve' | 'reject' | 'retry' | 'passed' | 'failed';
+
 export interface WorkflowStep {
   id: string;
   name: string;
+  /** Node type — defaults to 'agent_task' for backward compatibility. */
+  nodeType?: WorkflowNodeType;
+  /** Agent instance id (required for agent_task, ignored for gate/check). */
   agent: string;
   aiTool?: string;
   avatar?: string;
   description: string;
   nextSteps: string[];
+  /** Per-outgoing-edge conditional value, keyed by target step id. */
+  edgeWhen?: Record<string, EdgeWhen>;
   position?: { x: number; y: number };
 }
 

--- a/services/orchestrator/src/routes/chat.py
+++ b/services/orchestrator/src/routes/chat.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import uuid
 from typing import Any
 from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect, Response
@@ -464,3 +465,48 @@ async def stop_run(run_id: str) -> dict[str, str]:
 async def ws_run(websocket: WebSocket, run_id: str) -> None:
     from src.main import ws_run as main_ws_run
     await main_ws_run(websocket, run_id)
+
+
+@router.get("/api/openspec/list")
+async def openspec_list() -> dict[str, Any]:
+    """List all OpenSpec changes and their artifact statuses."""
+    import subprocess
+    import json as j
+    try:
+        result = subprocess.run(
+            ["openspec", "list", "--json"],
+            capture_output=True, text=True, timeout=15,
+            cwd=os.environ.get("OPENSPEC_WORKSPACE") or os.path.expanduser("~"),
+        )
+        if result.returncode != 0:
+            return {"available": False, "error": result.stderr.strip(), "changes": []}
+        data = j.loads(result.stdout) if result.stdout.strip() else {}
+        return {"available": True, "changes": data.get("changes", data.get("items", []))}
+    except FileNotFoundError:
+        return {"available": False, "error": "openspec CLI not found", "changes": []}
+    except subprocess.TimeoutExpired:
+        return {"available": False, "error": "openspec list timed out", "changes": []}
+    except Exception as exc:
+        return {"available": False, "error": str(exc), "changes": []}
+
+
+@router.get("/api/openspec/status")
+async def openspec_status(change: str) -> dict[str, Any]:
+    """Get detailed status of a single OpenSpec change."""
+    import subprocess
+    import json as j
+    try:
+        result = subprocess.run(
+            ["openspec", "status", "--change", change, "--json"],
+            capture_output=True, text=True, timeout=15,
+            cwd=os.environ.get("OPENSPEC_WORKSPACE") or os.path.expanduser("~"),
+        )
+        if result.returncode != 0:
+            return {"available": False, "error": result.stderr.strip()}
+        return {"available": True, "status": j.loads(result.stdout) if result.stdout.strip() else {}}
+    except FileNotFoundError:
+        return {"available": False, "error": "openspec CLI not found"}
+    except subprocess.TimeoutExpired:
+        return {"available": False, "error": "openspec status timed out"}
+    except Exception as exc:
+        return {"available": False, "error": str(exc)}


### PR DESCRIPTION
## Summary

First phase of OpenSpec integration into Clutch: adds an **OpenSpec tab** in the workflow editor's left sidebar that lists changes and their artifact statuses via the openspec CLI.

This is a **Draft PR** — the intent is to discuss the integration direction, not to merge immediately.

## What changed

### Sidecar (Python)
- `GET /api/openspec/list` — lists all OpenSpec changes
- `GET /api/openspec/status?change=<name>` — detailed artifact status of a single change

### Frontend (TypeScript/React)
- `openspecApi.ts` — API service for the two new endpoints
- `OpenSpecPanel.tsx` — tab panel showing:
  - Change list with status badges
  - Click to expand artifact detail (ready/blocked/pending)
  - Refresh button, install hint when CLI not found
- `WorkflowOrchestration.tsx` — tab switcher (Workflows | OpenSpec) in the left sidebar

## Future phases (if this direction is accepted)
- Phase 2: Canvas node types for proposal/design/tasks/spec artifacts
- Phase 3: check node integration with `openspec validate`

## Build
- 17 frontend tests + 734 backend tests: all passed
- Frontend build: success