### PR TITLE
fix(ci): unblock Windows Build for v1.4.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,7 @@ Layer 4 为**操作规程**，不是权威来源。冲突时以本文 §铁律 �
 - 上下文压缩 patch 含新 `system_digest_*` 时须**整表替换** messages，禁止 merge 追加（否则 `/compact` 只闪 toast、历史不变）
 - WKWebView `Can't find variable: useLanguage` / `useHostOs` → 组件调了 hook 却没 import；`pnpm build` 不报，须看 `hookImportGuard.test.ts`
 - `run_terminal_cmd` `shell=True` 后 `proc.kill()` 只杀到 shell，eslint 等子进程继续占满 CPU；超时/Kill 须进程组（`shell_proc.kill_tree`），同一命令已在跑则拒绝再开
+- Windows CI 后台 job 测 `sleep` 不要用 `timeout /t`：无控制台 + stdout PIPE 会立刻 `ERROR: Input redirection is not supported` 并以 exit 1 失败 → 用 `ping -n N 127.0.0.1 >nul`
 
 ---
 

--- a/memory/FAILURES.md
+++ b/memory/FAILURES.md
@@ -12,6 +12,14 @@
 
 （暂无）
 
+### [RESOLVED] Windows CI `test_start_sleep_wait_done` failed（2026-08-28）
+
+- **现象：** v1.4.0 tag 的 Windows Build 在 `uv run pytest` 挂掉：`test_bg_jobs_d11.py::test_start_sleep_wait_done` 期望 `done`，实际 `failed`。
+- **根因：** 测试用 `timeout /t … >nul`。GitHub `windows-latest` 无控制台且 stdout 为 PIPE，`timeout` 立刻报 Input redirection is not supported 并以非 0 退出。
+- **解决：** Windows 侧改为 `ping -n N 127.0.0.1 >nul`。
+- **规避：** 测 delay 不要用 `timeout`；杀进程组仍走 `taskkill /T`。
+- **关联：** `test_bg_jobs_d11.py` · `test_foreground_shell_d34.py`
+
 ### [RESOLVED] 前台 `npm run lint` 连开三趟把电脑打烫（2026-08-28）
 
 - **现象：** Chat 卡在 Working；前台条和 BACKGROUND JOBS 同时显示 `npm run lint`；本机 3 个 eslint 各 ~97% CPU。

--- a/services/orchestrator/tests/test_bg_jobs_d11.py
+++ b/services/orchestrator/tests/test_bg_jobs_d11.py
@@ -19,11 +19,12 @@ from src.builtin_tools import execute_builtin_tool
 
 _BG_DIR = tempfile.gettempdir()
 if sys.platform == "win32":
-    _SLEEP_DONE = "timeout /t 1 /nobreak >nul && echo done-bg"
-    _SLEEP_LONG = "timeout /t 30 /nobreak >nul"
-    _SLEEP_LIST = "timeout /t 5 /nobreak >nul"
-    _SLEEP_1 = "timeout /t 1 /nobreak >nul"
-    _SLEEP_2_ECHO = "timeout /t 2 /nobreak >nul && echo builtin-bg"
+    # `timeout` exits 1 under redirected stdout (CI has no console). ping is fine.
+    _SLEEP_DONE = "ping -n 2 127.0.0.1 >nul && echo done-bg"
+    _SLEEP_LONG = "ping -n 31 127.0.0.1 >nul"
+    _SLEEP_LIST = "ping -n 6 127.0.0.1 >nul"
+    _SLEEP_1 = "ping -n 2 127.0.0.1 >nul"
+    _SLEEP_2_ECHO = "ping -n 3 127.0.0.1 >nul && echo builtin-bg"
 else:
     _SLEEP_DONE = "sleep 1 && echo done-bg"
     _SLEEP_LONG = "sleep 30"

--- a/services/orchestrator/tests/test_foreground_shell_d34.py
+++ b/services/orchestrator/tests/test_foreground_shell_d34.py
@@ -20,9 +20,10 @@ from src.foreground_shell import (
 
 _BG_DIR = tempfile.gettempdir()
 if sys.platform == "win32":
-    _FG_LONG = "timeout /t 30 /nobreak >nul && echo FG_DONE"
-    _FG_LONG_PLAIN = "timeout /t 30 /nobreak >nul"
-    _BUILTIN_LONG = "timeout /t 30 /nobreak >nul && echo builtin-fg"
+    # `timeout` exits 1 under redirected stdout (CI has no console). ping is fine.
+    _FG_LONG = "ping -n 31 127.0.0.1 >nul && echo FG_DONE"
+    _FG_LONG_PLAIN = "ping -n 31 127.0.0.1 >nul"
+    _BUILTIN_LONG = "ping -n 31 127.0.0.1 >nul && echo builtin-fg"
 else:
     _FG_LONG = "sleep 30 && echo FG_DONE"
     _FG_LONG_PLAIN = "sleep 30"


### PR DESCRIPTION
## Summary
- Windows CI pytest used `timeout /t`, which exits 1 when stdout is piped (no console). That failed `test_start_sleep_wait_done` and skipped `tauri:build`.
- Tests now use `ping -n N 127.0.0.1 >nul` on Windows.

After merge, retag `v1.4.0` so Windows Build and (if needed) Release re-run.

## Test plan
- [x] `uv run pytest tests/test_bg_jobs_d11.py tests/test_foreground_shell_d34.py`
- [ ] Windows Build on the moved `v1.4.0` tag reaches `pnpm tauri:build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Windows delay commands and documentation; no production shell or CI workflow logic changes.
> 
> **Overview**
> Unblocks **Windows Build** on v1.4.0 by fixing orchestrator pytest that simulated sleep with `timeout /t` on Windows.
> 
> On GitHub `windows-latest` (no console, piped stdout), `timeout` fails immediately with *Input redirection is not supported* and exit code 1, so `test_start_sleep_wait_done` saw jobs as `failed` instead of `done` and blocked `pnpm tauri:build`.
> 
> **Windows-only** sleep helpers in `test_bg_jobs_d11.py` and `test_foreground_shell_d34.py` now use `ping -n N 127.0.0.1 >nul` with adjusted counts for ~1–30s delays; Unix paths still use `sleep`. Docs record the pitfall in `CLAUDE.md` §已知陷阱 and a `[RESOLVED]` entry in `memory/FAILURES.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ddb9004957d0f6de3d057df3a92ed48209e5974. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->